### PR TITLE
Flatten byte chunks in byte stream responses

### DIFF
--- a/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/StreamingOutputResult.scala
+++ b/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/StreamingOutputResult.scala
@@ -4,7 +4,7 @@ import zio.Chunk
 import zio.stream.ZStream
 
 case class StreamingOutputResult[Response](response: Response,
-                                           output: ZStream[Any, AwsError, Chunk[Byte]]) {
+                                           output: ZStream[Any, AwsError, Byte]) {
   def map[R](f: Response => R): StreamingOutputResult[R] =
     copy(response = f(response))
 }

--- a/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/AwsServiceBaseSpec.scala
+++ b/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/AwsServiceBaseSpec.scala
@@ -63,7 +63,7 @@ object AwsServiceBaseSpec extends DefaultRunnableSpec with AwsServiceBase {
 
       for {
         result <- asyncRequestOutputStream(fakeAwsCall)("hello")
-        streamResult <- result.output.runCollect.map(_.flatten.toVector)
+        streamResult <- result.output.runCollect.map(_.toVector)
       } yield assert(streamResult)(equalTo("hello".getBytes(StandardCharsets.US_ASCII).toVector)) &&
         assert(result.response)(equalTo(5))
     },
@@ -137,7 +137,7 @@ object AwsServiceBaseSpec extends DefaultRunnableSpec with AwsServiceBase {
 
       for {
         result <- asyncRequestInputOutputStream(fakeAwsCall)(2, ZStream.fromIterable("hello".getBytes(StandardCharsets.US_ASCII)).grouped(2))
-        streamResult <- result.output.runCollect.map(_.flatten.toVector)
+        streamResult <- result.output.runCollect.map(_.toVector)
       } yield assert(streamResult)(equalTo("hheelllloo".getBytes(StandardCharsets.US_ASCII).toVector)) &&
         assert(result.response)(equalTo(5))
     },


### PR DESCRIPTION
Streams are already chunked, so a `Stream[AwsError, Chunk[Byte]]` is superfluous.