### PR TITLE
Streaming support for more paginated operations

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ val awsSubVersion = awsVersion.drop(awsVersion.indexOf('.') + 1)
 val http4sVersion = "0.21.7"
 val fs2Version = "2.2.2"
 
-val majorVersion = "1"
-val minorVersion = "1"
+val majorVersion = "2"
+val minorVersion = "0"
 val zioAwsVersion = s"$majorVersion.$awsSubVersion.$minorVersion"
 
 val generateAll = taskKey[Unit]("Generates all AWS client libraries")

--- a/examples/build.sbt
+++ b/examples/build.sbt
@@ -1,9 +1,9 @@
 
 val commonSettings = Seq(
-  scalaVersion := "2.13.2"
+  scalaVersion := "2.13.3"
 )
 
-val zioAwsVersion = "1.13.69.1"
+val zioAwsVersion = "2.14.2.0"
 
 lazy val example1 = Project("example1", file("example1")).settings(commonSettings).settings(
   libraryDependencies ++= Seq(

--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/GeneratorFailure.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/GeneratorFailure.scala
@@ -9,3 +9,4 @@ case class FailedToDelete(reason: Throwable) extends GeneratorFailure
 case class CannotFindEventStreamInShape(service: String, name: String) extends GeneratorFailure
 case class UnknownShapeReference(service: String, name: String) extends GeneratorFailure
 case class UnknownType(service: String, typ: String) extends GeneratorFailure
+case class InvalidPaginatedOperation(service: String, name: String) extends GeneratorFailure

--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/OperationCollector.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/OperationCollector.scala
@@ -2,6 +2,7 @@ package io.github.vigoo.zioaws.codegen.generator
 
 import io.github.vigoo.zioaws.codegen.generator.TypeMapping.{toJavaType, toWrappedTypeReadOnly}
 import io.github.vigoo.zioaws.codegen.generator.context._
+import io.github.vigoo.zioaws.codegen.loader
 import software.amazon.awssdk.codegen.C2jModels
 import software.amazon.awssdk.codegen.model.config.customization.CustomizationConfig
 import software.amazon.awssdk.codegen.model.service.{Operation, Shape}
@@ -10,34 +11,39 @@ import zio.ZIO
 import scala.jdk.CollectionConverters._
 
 object OperationCollector {
-  private def isExcluded(customizationConfig: CustomizationConfig, opName: String): Boolean =
-    Option(customizationConfig.getOperationModifiers)
-      .flatMap(_.asScala.get(opName))
-      .exists(_.isExclude)
+  val overrides: Set[PaginationOverride] = Set(
+    PaginationNotSupported(loader.ModelId("greengrass", None), "GetDeviceDefinitionVersion"),
+    PaginationNotSupported(loader.ModelId("greengrass", None), "GetSubscriptionDefinitionVersion"),
+    PaginationNotSupported(loader.ModelId("greengrass", None), "GetFunctionDefinitionVersion"),
+    PaginationNotSupported(loader.ModelId("greengrass", None), "GetConnectorDefinitionVersion"),
+    PaginationNotSupported(loader.ModelId("budgets", None), "DescribeBudgetPerformanceHistory"),
+
+    PaginationNotSupported(loader.ModelId("athena", None), "GetQueryResults"),
+    PaginationNotSupported(loader.ModelId("guardduty", None), "GetUsageStatistics"),
+
+    SelectPaginatedStringMember(loader.ModelId("fms", None), "GetProtectionStatus", "Data"),
+
+    SelectPaginatedListMember(loader.ModelId("cloudformation", None), "DescribeChangeSet", "Changes"),
+    SelectPaginatedListMember(loader.ModelId("ec2", None), "DescribeVpcEndpointServices", "ServiceDetails"),
+    SelectPaginatedListMember(loader.ModelId("pi", None), "DescribeDimensionKeys", "Keys"),
+    SelectPaginatedListMember(loader.ModelId("cognitosync", None), "ListRecords", "Records"),
+    SelectPaginatedListMember(loader.ModelId("textract", None), "GetDocumentAnalysis", "Blocks"),
+    SelectPaginatedListMember(loader.ModelId("textract", None), "GetDocumentTextDetection", "Blocks"),
+
+    SelectPaginatedListMember(loader.ModelId("resourcegroups", None), "ListGroups", "Groups"),
+    SelectPaginatedListMember(loader.ModelId("resourcegroups", None), "SearchResources", "ResourceIdentifiers"),
+    SelectPaginatedListMember(loader.ModelId("resourcegroups", None), "ListGroupResources", "ResourceIdentifiers"),
+  )
+
+  case class OverrideKey(id: loader.ModelId, opName: String)
+
+  val overrideMap: Map[OverrideKey, PaginationOverride] = overrides.map(o => o.toKey -> o).toMap
 
   def getFilteredOperations(models: C2jModels): Map[String, Operation] =
     models.serviceModel().getOperations.asScala
       .toMap
       .filter { case (_, op) => !op.isDeprecated }
       .filter { case (opName, _) => !isExcluded(models.customizationConfig(), opName) }
-
-  private def hasStreamingMember(models: C2jModels, shape: Shape, alreadyChecked: Set[Shape] = Set.empty): Boolean =
-    if (alreadyChecked(shape)) {
-      false
-    } else {
-      shape.isStreaming || shape.getMembers.asScala.values.exists { member =>
-        member.isStreaming || hasStreamingMember(models, models.serviceModel().getShape(member.getShape), alreadyChecked + shape)
-      }
-    }
-
-  private def hasEventStreamMember(models: C2jModels, shape: Shape, alreadyChecked: Set[Shape] = Set.empty): Boolean =
-    if (alreadyChecked(shape)) {
-      false
-    } else {
-      shape.isEventStream || shape.getMembers.asScala.values.exists { member =>
-        hasEventStreamMember(models, models.serviceModel().getShape(member.getShape), alreadyChecked + shape)
-      }
-    }
 
   def inputIsStreamingOf(models: C2jModels, op: Operation): Boolean =
     Option(op.getInput).flatMap(input => Option(models.serviceModel().getShape(input.getShape))).exists(hasStreamingMember(models, _))
@@ -73,58 +79,171 @@ object OperationCollector {
         } else if (outputIsEventStream) {
           ZIO.succeed(EventStreamOutput)
         } else {
-          Option(models.paginatorsModel().getPaginatorDefinition(opName)) match {
-            case Some(paginator) if paginator.isValid =>
-              Option(paginator.getResultKey).flatMap(_.asScala.headOption) match {
-                case Some(key) =>
-                  val outputShape = models.serviceModel().getShape(op.getOutput.getShape)
-                  outputShape.getMembers.asScala.get(key) match {
-                    case Some(outputListMember) =>
-                      val listShape = models.serviceModel().getShape(outputListMember.getShape)
-                      Option(listShape.getListMember) match {
-                        case Some(itemMember) =>
-                          for {
-                            itemModel <- context.get(itemMember.getShape)
-                            itemType <- toJavaType(itemModel)
-                            wrappedTypeRo <- toWrappedTypeReadOnly(itemModel)
-                          } yield RequestResponse(pagination = Some(PaginationDefinition(
-                            name = key,
-                            model = itemModel,
-                            itemType = itemType,
-                            wrappedTypeRo = wrappedTypeRo
-                          )))
-                        case None =>
-                          ZIO.succeed(RequestResponse(pagination = None))
-                      }
-                    case None =>
-                      ZIO.succeed(RequestResponse(pagination = None))
-                  }
+          if (op.getOutput == null && op.getInput == null) {
+            ZIO.succeed(UnitToUnit)
+          } else if (op.getOutput == null) {
+            ZIO.succeed(RequestToUnit)
+          } else if (op.getInput == null) {
+            ZIO.succeed(UnitToResponse)
+          } else {
+
+            val outputShape = models.serviceModel().getShape(op.getOutput.getShape)
+            val inputShape = models.serviceModel().getShape(op.getInput.getShape)
+
+            if (outputShape.getMembers.containsKey("NextToken") &&
+              inputShape.getMembers.containsKey("NextToken")) {
+
+              getPaginationDefinition(opName, op).map { paginationDefinition =>
+                RequestResponse(paginationDefinition)
+              }
+            } else {
+              getJavaSdkPaginatorDefinition(opName, op, models) match {
+                case Some(createDef) =>
+                  // Special paginator with Java SDK support
+                  for {
+                    paginatorDef <- createDef
+                  } yield RequestResponse(pagination = Some(paginatorDef))
                 case None =>
                   ZIO.succeed(RequestResponse(pagination = None))
               }
-            case _ =>
-              if (op.getOutput == null && op.getInput == null) {
-                ZIO.succeed(UnitToUnit)
-              } else if (op.getOutput == null) {
-                ZIO.succeed(RequestToUnit)
-              } else if (op.getInput == null) {
-                ZIO.succeed(UnitToResponse)
-              } else {
-
-                val outputShape = models.serviceModel().getShape(op.getOutput.getShape)
-                val inputShape = models.serviceModel().getShape(op.getInput.getShape)
-
-                if (outputShape.getMembers.containsKey("NextToken") &&
-                  inputShape.getMembers.containsKey("NextToken")) {
-                  // TODO: custom pagination
-                  ZIO.succeed(RequestResponse(pagination = None))
-                } else {
-                  ZIO.succeed(RequestResponse(pagination = None))
-                }
-              }
+            }
           }
         }
       }
     }
   }
+
+  private def getPaginationDefinition(opName: String, op: Operation): ZIO[GeneratorContext, GeneratorFailure, Option[PaginationDefinition]] = {
+    getService.flatMap { id =>
+      getModels.flatMap { models =>
+        val outputShape = models.serviceModel().getShape(op.getOutput.getShape)
+
+        overrideMap.get(OverrideKey(id, opName)) match {
+          case Some(PaginationNotSupported(_, _)) =>
+            ZIO.none
+          case Some(SelectPaginatedListMember(_, _, memberName)) =>
+            val listShapeName = outputShape.getMembers.get(memberName).getShape
+            for {
+              listModel <- context.get(listShapeName)
+              listShape = listModel.shape
+              itemShapeName = listShape.getListMember.getShape
+              itemModel <- context.get(itemShapeName)
+            } yield Some(ListPaginationDefinition(memberName, listModel, itemModel, isSimple = false))
+          case Some(SelectPaginatedStringMember(_, _, memberName)) =>
+            val stringShapeName = outputShape.getMembers.get(memberName).getShape
+            for {
+              stringModel <- context.get(stringShapeName)
+            } yield Some(StringPaginationDefinition(memberName, stringModel, isSimple = false))
+          case None =>
+            val otherOutputMembers = outputShape.getMembers.asScala.toMap - "NextToken"
+            val outputMembersWithListType = otherOutputMembers.filter { case (name, member) =>
+              models.serviceModel().getShape(member.getShape).getType == "list"
+            }
+            val outputMembersWithMapType = otherOutputMembers.filter { case (name, member) =>
+              models.serviceModel().getShape(member.getShape).getType == "map"
+            }
+            val outputMembersWithStringType = otherOutputMembers.filter { case (name, member) =>
+              val shape = models.serviceModel().getShape(member.getShape)
+              shape.getType == "string" && Option(shape.getEnumValues).map(_.asScala).getOrElse(List.empty).isEmpty
+            }
+
+            val isSimple = otherOutputMembers.size == 1
+
+            if (outputMembersWithListType.size == 1) {
+              val memberName = outputMembersWithListType.keys.head
+              val listShapeName = outputMembersWithListType.values.head.getShape
+              for {
+                listModel <- context.get(listShapeName)
+                listShape = listModel.shape
+                itemShapeName = listShape.getListMember.getShape
+                itemModel <- context.get(itemShapeName)
+              } yield Some(ListPaginationDefinition(memberName, listModel, itemModel, isSimple))
+            } else if (outputMembersWithMapType.size == 1) {
+              val memberName = outputMembersWithMapType.keys.head
+              val mapShapeName = outputMembersWithMapType.values.head.getShape
+              for {
+                mapModel <- context.get(mapShapeName)
+                mapShape = mapModel.shape
+                keyModel <- context.get(mapShape.getMapKeyType.getShape)
+                valueModel <- context.get(mapShape.getMapValueType.getShape)
+              } yield Some(MapPaginationDefinition(memberName, mapModel, keyModel, valueModel, isSimple))
+            } else if (outputMembersWithStringType.size == 1) {
+              val memberName = outputMembersWithStringType.keys.head
+              val stringShapeName = outputMembersWithStringType.values.head.getShape
+              for {
+                stringModel <- context.get(stringShapeName)
+              } yield Some(StringPaginationDefinition(memberName, stringModel, isSimple))
+            } else {
+              // Fall back to Java SDK paginator if possible
+              getJavaSdkPaginatorDefinition(opName, op, models) match {
+                case Some(definition) =>
+                  definition.map(Some(_))
+                case None =>
+                  ZIO.fail(InvalidPaginatedOperation(id.toString, opName))
+              }
+            }
+        }
+      }
+    }
+  }
+
+  private def getJavaSdkPaginatorDefinition(opName: String, op: Operation, models: C2jModels) = {
+    for {
+      paginator <- Option(models.paginatorsModel().getPaginatorDefinition(opName))
+      if paginator.isValid
+      key <- Option(paginator.getResultKey).flatMap(_.asScala.headOption)
+      outputShape = models.serviceModel().getShape(op.getOutput.getShape)
+      outputListMember <- outputShape.getMembers.asScala.get(key)
+      listShape = models.serviceModel().getShape(outputListMember.getShape)
+      itemMember <- Option(listShape.getListMember)
+    } yield for {
+      itemModel <- context.get(itemMember.getShape)
+      itemType <- toJavaType(itemModel)
+      wrappedTypeRo <- toWrappedTypeReadOnly(itemModel)
+    } yield JavaSdkPaginationDefinition(
+      name = key,
+      model = itemModel,
+      itemType = itemType,
+      wrappedTypeRo = wrappedTypeRo)
+  }
+
+  private def isExcluded(customizationConfig: CustomizationConfig, opName: String): Boolean =
+    Option(customizationConfig.getOperationModifiers)
+      .flatMap(_.asScala.get(opName))
+      .exists(_.isExclude)
+
+  private def hasStreamingMember(models: C2jModels, shape: Shape, alreadyChecked: Set[Shape] = Set.empty): Boolean =
+    if (alreadyChecked(shape)) {
+      false
+    } else {
+      shape.isStreaming || shape.getMembers.asScala.values.exists { member =>
+        member.isStreaming || hasStreamingMember(models, models.serviceModel().getShape(member.getShape), alreadyChecked + shape)
+      }
+    }
+
+  private def hasEventStreamMember(models: C2jModels, shape: Shape, alreadyChecked: Set[Shape] = Set.empty): Boolean =
+    if (alreadyChecked(shape)) {
+      false
+    } else {
+      shape.isEventStream || shape.getMembers.asScala.values.exists { member =>
+        hasEventStreamMember(models, models.serviceModel().getShape(member.getShape), alreadyChecked + shape)
+      }
+    }
+
+  sealed trait PaginationOverride {
+    def toKey: OverrideKey
+  }
+
+  case class PaginationNotSupported(id: loader.ModelId, opName: String) extends PaginationOverride {
+    override def toKey: OverrideKey = OverrideKey(id, opName)
+  }
+
+  case class SelectPaginatedListMember(id: loader.ModelId, opName: String, memberName: String) extends PaginationOverride {
+    override def toKey: OverrideKey = OverrideKey(id, opName)
+  }
+
+  case class SelectPaginatedStringMember(id: loader.ModelId, opName: String, memberName: String) extends PaginationOverride {
+    override def toKey: OverrideKey = OverrideKey(id, opName)
+  }
+
 }

--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/PaginationDefinition.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/PaginationDefinition.scala
@@ -2,8 +2,24 @@ package io.github.vigoo.zioaws.codegen.generator
 
 import scala.meta.Type
 
-case class PaginationDefinition(name: String,
-                                model: Model,
-                                itemType: Type,
-                                wrappedTypeRo: Type)
+sealed trait PaginationDefinition
 
+case class JavaSdkPaginationDefinition(name: String,
+                                       model: Model,
+                                       itemType: Type,
+                                       wrappedTypeRo: Type) extends PaginationDefinition
+
+case class ListPaginationDefinition(memberName: String,
+                                    listModel: Model,
+                                    itemModel: Model,
+                                    isSimple: Boolean) extends PaginationDefinition
+
+case class MapPaginationDefinition(memberName: String,
+                                   mapModel: Model,
+                                   keyModel: Model,
+                                   valueModel: Model,
+                                   isSimple: Boolean) extends PaginationDefinition
+
+case class StringPaginationDefinition(memberName: String,
+                                      stringModel: Model,
+                                      isSimple: Boolean) extends PaginationDefinition

--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/ServiceModelGenerator.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/ServiceModelGenerator.scala
@@ -57,30 +57,6 @@ trait ServiceModelGenerator {
     }
   }
 
-  private def propertyName(model: Model, fieldModel: Model, name: String): ZIO[GeneratorContext, Nothing, String] = {
-    getNamingStrategy.flatMap { namingStrategy =>
-      getModels.map { models =>
-        val shapeModifiers = Option(models.customizationConfig().getShapeModifiers).map(_.asScala).getOrElse(Map.empty[String, ShapeModifier])
-        shapeModifiers.get(model.shapeName).flatMap { shapeModifier =>
-          val modifies = Option(shapeModifier.getModify).map(_.asScala).getOrElse(List.empty)
-          val matchingModifiers = modifies.flatMap { modifiesMap =>
-            modifiesMap.asScala.map { case (key, value) => (key.toLowerCase, value) }.get(name.toLowerCase)
-          }.toList
-
-          matchingModifiers
-            .map(modifier => Option(modifier.getEmitPropertyName))
-            .find(_.isDefined)
-            .flatten.map(_.uncapitalize)
-        }.getOrElse {
-          val getterMethod = namingStrategy.getFluentGetterMethodName(name, model.shape, fieldModel.shape)
-          getterMethod
-            .stripSuffix("AsString")
-            .stripSuffix("AsStrings")
-        }
-      }
-    }
-  }
-
   private def applyEnumModifiers(model: Model, enumValueList: List[String]): ZIO[GeneratorContext, Nothing, List[String]] = {
     getModels.map { models =>
       val shapeModifiers = Option(models.customizationConfig().getShapeModifiers).map(_.asScala).getOrElse(Map.empty[String, ShapeModifier])

--- a/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/AwsServiceBase.scala
+++ b/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/AwsServiceBase.scala
@@ -48,7 +48,7 @@ trait AwsServiceBase {
                 } yield chunk
               } yield pull
             }
-            ZIO.succeed(stream)
+            ZIO.succeed(ZStream.fromChunk(getItems(response)).concat(stream))
           case None =>
             // No pagination
             ZIO.succeed(ZStream.fromChunk(getItems(response)))
@@ -82,7 +82,7 @@ trait AwsServiceBase {
               } yield chunk
             } yield pull
           }
-          ZIO.succeed(StreamingOutputResult(response, stream))
+          ZIO.succeed(StreamingOutputResult(response, ZStream.fromChunk(getItems(response)).concat(stream)))
         case None =>
           // No pagination
           ZIO.succeed(StreamingOutputResult(response, ZStream.fromChunk(getItems(response))))

--- a/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/AwsServiceBase.scala
+++ b/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/AwsServiceBase.scala
@@ -13,16 +13,85 @@ import zio.stream.ZStream.TerminationStrategy
 import scala.reflect.ClassTag
 
 trait AwsServiceBase {
-  final def asyncRequestResponse[Request, Response](impl: Request => CompletableFuture[Response])(request: Request): IO[AwsError, Response] =
+  final protected def asyncRequestResponse[Request, Response](impl: Request => CompletableFuture[Response])(request: Request): IO[AwsError, Response] =
     ZIO.fromCompletionStage(impl(request)).mapError(AwsError.fromThrowable)
 
-  final def asyncPaginatedRequest[Request, Item, Response](impl: Request => Response, selector: Response => Publisher[Item])(request: Request): ZStream[Any, AwsError, Item] =
+  final protected def asyncJavaPaginatedRequest[Request, Item, Response](impl: Request => Response, selector: Response => Publisher[Item])(request: Request): ZStream[Any, AwsError, Item] =
     ZStream.unwrap {
       ZIO(selector(impl(request)).toStream().mapError(AwsError.fromThrowable)).mapError(AwsError.fromThrowable)
     }
 
-  final def asyncRequestOutputStream[Request, Response](impl: (Request, AsyncResponseTransformer[Response, Task[StreamingOutputResult[Response]]]) => CompletableFuture[Task[StreamingOutputResult[Response]]])
-                                                       (request: Request): IO[AwsError, StreamingOutputResult[Response]] = {
+  final protected def asyncSimplePaginatedRequest[Request, Response, Item](impl: Request => CompletableFuture[Response],
+                                                                           setNextToken: (Request, String) => Request,
+                                                                           getNextToken: Response => Option[String],
+                                                                           getItems: Response => Chunk[Item])
+                                                                          (request: Request): ZStream[Any, AwsError, Item] =
+    ZStream.unwrap {
+      ZIO.fromCompletionStage(impl(request)).mapError(AwsError.fromThrowable).flatMap { response =>
+        getNextToken(response) match {
+          case Some(nextToken) =>
+            val stream = ZStream {
+              for {
+                nextTokenRef <- Ref.make[Option[String]](Some(nextToken)).toManaged_
+                pull = for {
+                  token <- nextTokenRef.get
+                  chunk <- token match {
+                    case Some(t) =>
+                      for {
+                        nextRequest <- ZIO.effect(setNextToken(request, t)).mapError(t => Some(GenericAwsError(t)))
+                        rsp <- ZIO.fromCompletionStage(impl(nextRequest)).mapError(t => Some(GenericAwsError(t)))
+                        _ <- nextTokenRef.set(getNextToken(rsp))
+                      } yield getItems(rsp)
+                    case None =>
+                      IO.fail(None)
+                  }
+                } yield chunk
+              } yield pull
+            }
+            ZIO.succeed(stream)
+          case None =>
+            // No pagination
+            ZIO.succeed(ZStream.fromChunk(getItems(response)))
+        }
+      }
+    }
+
+  final protected def asyncPaginatedRequest[Request, Response, Item](impl: Request => CompletableFuture[Response],
+                                                                     setNextToken: (Request, String) => Request,
+                                                                     getNextToken: Response => Option[String],
+                                                                     getItems: Response => Chunk[Item])
+                                                                    (request: Request): IO[AwsError, StreamingOutputResult[Response, Item]] = {
+      ZIO.fromCompletionStage(impl(request)).mapError(AwsError.fromThrowable).flatMap { response =>
+      getNextToken(response) match {
+        case Some(nextToken) =>
+          val stream = ZStream {
+            for {
+              nextTokenRef <- Ref.make[Option[String]](Some(nextToken)).toManaged_
+              pull = for {
+                token <- nextTokenRef.get
+                chunk <- token match {
+                  case Some(t) =>
+                    for {
+                      nextRequest <- ZIO.effect(setNextToken(request, t)).mapError(t => Some(GenericAwsError(t)))
+                      rsp <- ZIO.fromCompletionStage(impl(nextRequest)).mapError(t => Some(GenericAwsError(t)))
+                      _ <- nextTokenRef.set(getNextToken(rsp))
+                    } yield getItems(rsp)
+                  case None =>
+                    IO.fail(None)
+                }
+              } yield chunk
+            } yield pull
+          }
+          ZIO.succeed(StreamingOutputResult(response, stream))
+        case None =>
+          // No pagination
+          ZIO.succeed(StreamingOutputResult(response, ZStream.fromChunk(getItems(response))))
+      }
+    }
+  }
+
+  final protected def asyncRequestOutputStream[Request, Response](impl: (Request, AsyncResponseTransformer[Response, Task[StreamingOutputResult[Response, Byte]]]) => CompletableFuture[Task[StreamingOutputResult[Response, Byte]]])
+                                                                 (request: Request): IO[AwsError, StreamingOutputResult[Response, Byte]] = {
     for {
       transformer <- ZStreamAsyncResponseTransformer[Response]()
       streamingOutputResultTask <- ZIO.fromCompletionStage(impl(request, transformer)).mapError(AwsError.fromThrowable)
@@ -30,14 +99,14 @@ trait AwsServiceBase {
     } yield streamingOutputResult
   }
 
-  final def asyncRequestInputStream[Request, Response](impl: (Request, AsyncRequestBody) => CompletableFuture[Response])
-                                                      (request: Request, body: ZStream[Any, AwsError, Byte]): IO[AwsError, Response] =
+  final protected def asyncRequestInputStream[Request, Response](impl: (Request, AsyncRequestBody) => CompletableFuture[Response])
+                                                                (request: Request, body: ZStream[Any, AwsError, Byte]): IO[AwsError, Response] =
     ZIO.runtime.flatMap { implicit runtime: Runtime[Any] =>
       ZIO.fromCompletionStage(impl(request, new ZStreamAsyncRequestBody(body))).mapError(AwsError.fromThrowable)
     }
 
-  final def asyncRequestInputOutputStream[Request, Response](impl: (Request, AsyncRequestBody, AsyncResponseTransformer[Response, Task[StreamingOutputResult[Response]]]) => CompletableFuture[Task[StreamingOutputResult[Response]]])
-                                                            (request: Request, body: ZStream[Any, AwsError, Byte]): IO[AwsError, StreamingOutputResult[Response]] = {
+  final protected def asyncRequestInputOutputStream[Request, Response](impl: (Request, AsyncRequestBody, AsyncResponseTransformer[Response, Task[StreamingOutputResult[Response, Byte]]]) => CompletableFuture[Task[StreamingOutputResult[Response, Byte]]])
+                                                                      (request: Request, body: ZStream[Any, AwsError, Byte]): IO[AwsError, StreamingOutputResult[Response, Byte]] = {
     ZIO.runtime.flatMap { implicit runtime: Runtime[Any] =>
       for {
         transformer <- ZStreamAsyncResponseTransformer[Response]()
@@ -47,7 +116,7 @@ trait AwsServiceBase {
     }
   }
 
-  final def asyncRequestEventOutputStream[
+  final protected def asyncRequestEventOutputStream[
     Request,
     Response,
     ResponseHandler <: EventStreamResponseHandler[Response, EventI],
@@ -88,14 +157,14 @@ trait AwsServiceBase {
     }
   }
 
-  final def asyncRequestEventInputStream[Request, Response, Event](impl: (Request, Publisher[Event]) => CompletableFuture[Response])
-                                                                  (request: Request, input: ZStream[Any, AwsError, Event]): IO[AwsError, Response] =
+  final protected def asyncRequestEventInputStream[Request, Response, Event](impl: (Request, Publisher[Event]) => CompletableFuture[Response])
+                                                                            (request: Request, input: ZStream[Any, AwsError, Event]): IO[AwsError, Response] =
     for {
       publisher <- input.mapError(_.toThrowable).toPublisher
       response <- ZIO.fromCompletionStage(impl(request, publisher)).mapError(AwsError.fromThrowable)
     } yield response
 
-  final def asyncRequestEventInputOutputStream[
+  final protected def asyncRequestEventInputOutputStream[
     Request,
     Response,
     InEvent,

--- a/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/StreamingOutputResult.scala
+++ b/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/StreamingOutputResult.scala
@@ -2,8 +2,11 @@ package io.github.vigoo.zioaws.core
 
 import zio.stream.ZStream
 
-case class StreamingOutputResult[Response](response: Response,
-                                           output: ZStream[Any, AwsError, Byte]) {
-  def map[R](f: Response => R): StreamingOutputResult[R] =
+case class StreamingOutputResult[Response, Item](response: Response,
+                                           output: ZStream[Any, AwsError, Item]) {
+  def mapResponse[R](f: Response => R): StreamingOutputResult[R, Item] =
     copy(response = f(response))
+
+  def mapOutput[I](f: ZStream[Any, AwsError, Item] => ZStream[Any, AwsError, I]): StreamingOutputResult[Response, I] =
+    copy(output = f(output))
 }

--- a/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/ZStreamAsyncResponseTransformer.scala
+++ b/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/ZStreamAsyncResponseTransformer.scala
@@ -12,9 +12,9 @@ class ZStreamAsyncResponseTransformer[Response](resultStreamPromise: Promise[Thr
                                                 responsePromise: Promise[Throwable, Response],
                                                 errorPromise: Promise[Throwable, Unit])
                                                (implicit runtime: Runtime[Any])
-  extends AsyncResponseTransformer[Response, Task[StreamingOutputResult[Response]]] {
+  extends AsyncResponseTransformer[Response, Task[StreamingOutputResult[Response, Byte]]] {
 
-  override def prepare(): CompletableFuture[Task[StreamingOutputResult[Response]]] =
+  override def prepare(): CompletableFuture[Task[StreamingOutputResult[Response, Byte]]] =
     CompletableFuture.completedFuture {
       for {
         response <- responsePromise.await

--- a/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/sim/SimulatedAsyncResponseTransformer.scala
+++ b/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/sim/SimulatedAsyncResponseTransformer.scala
@@ -17,12 +17,12 @@ object SimulatedAsyncResponseTransformer {
 
 
   def useAsyncResponseTransformer[In, Out](in: In,
-                                           transformer: AsyncResponseTransformer[Out, Task[StreamingOutputResult[Out]]],
+                                           transformer: AsyncResponseTransformer[Out, Task[StreamingOutputResult[Out, Byte]]],
                                            toResult: In => Out,
                                            toPublisher: In => SdkPublisher[ByteBuffer],
                                            failureSpec: FailureSpec)
-                                          (implicit threadPool: ExecutorService): CompletableFuture[Task[StreamingOutputResult[Out]]] = {
-    val cf = new CompletableFuture[Task[StreamingOutputResult[Out]]]()
+                                          (implicit threadPool: ExecutorService): CompletableFuture[Task[StreamingOutputResult[Out, Byte]]] = {
+    val cf = new CompletableFuture[Task[StreamingOutputResult[Out, Byte]]]()
     threadPool.submit(new Runnable {
       override def run(): Unit = {
         useAsyncResponseTransformerImpl(in, transformer, toResult, toPublisher, failureSpec, cf)
@@ -32,17 +32,17 @@ object SimulatedAsyncResponseTransformer {
   }
 
   def useAsyncResponseTransformerImpl[Out, In](in: In,
-                                               transformer: AsyncResponseTransformer[Out, Task[StreamingOutputResult[Out]]],
+                                               transformer: AsyncResponseTransformer[Out, Task[StreamingOutputResult[Out, Byte]]],
                                                toResult: In => Out,
                                                toPublisher: In => SdkPublisher[ByteBuffer],
                                                failureSpec: FailureSpec,
-                                               cf: CompletableFuture[Task[StreamingOutputResult[Out]]]): Unit = {
+                                               cf: CompletableFuture[Task[StreamingOutputResult[Out, Byte]]]): Unit = {
     failureSpec.failBeforePrepare match {
       case Some(throwable) =>
         cf.completeExceptionally(throwable)
       case None =>
         slowDown()
-        transformer.prepare().thenApply[Boolean] { (result: Task[StreamingOutputResult[Out]]) =>
+        transformer.prepare().thenApply[Boolean] { (result: Task[StreamingOutputResult[Out, Byte]]) =>
           slowDown()
           transformer.onResponse(toResult(in))
 

--- a/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/sim/SimulatedPagination.scala
+++ b/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/sim/SimulatedPagination.scala
@@ -1,0 +1,39 @@
+package io.github.vigoo.zioaws.core.sim
+
+import java.util.concurrent.{CompletableFuture, ExecutorService}
+
+object SimulatedPagination {
+
+  case class PaginatedRequest(input: String, token: Option[String])
+  case class PaginatedResult(output: List[Char], next: Option[String])
+
+  def simplePagination(failAfter: Option[Int], failure: Throwable)(request: PaginatedRequest)(implicit threadPool: ExecutorService): CompletableFuture[PaginatedResult] = {
+    val cf = new CompletableFuture[PaginatedResult]()
+
+    threadPool.submit(new Runnable {
+      override def run(): Unit = {
+        val startIdx = request.token match {
+          case Some(value) =>
+            value.toInt
+          case None =>
+            0
+        }
+
+        if (startIdx >= failAfter.getOrElse(Int.MaxValue)) {
+          cf.completeExceptionally(failure)
+        } else {
+          val chunk = request.input.substring(startIdx, Math.min(request.input.length, startIdx + 2)).toList
+          val nextIndex = startIdx + 2
+          val nextToken = if (nextIndex >= request.input.length) None else Some(nextIndex.toString)
+
+          cf.complete(PaginatedResult(
+            chunk,
+            nextToken
+          ))
+        }
+      }
+    })
+
+    cf
+  }
+}


### PR DESCRIPTION
Modifies the wrapper interface to streaming for more operations that has a `NextToken` based pagination, and only falls back to the Java SDK provided paginators in some edge cases.

Solves #6 