### PR TITLE
Auto release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,16 @@ before_install:
 - if [ "$COMMANDS" = "clean integtests/test" ]; then docker run -d -p 4566:4566 localstack/localstack;
   fi
 env:
-- COMMANDS="clean zio-aws-accessanalyzer/compile zio-aws-acm/compile zio-aws-acmpca/compile
+#- COMMANDS="clean zio-aws-accessanalyzer/compile zio-aws-acm/compile zio-aws-acmpca/compile
+#  zio-aws-alexaforbusiness/compile zio-aws-amplify/compile zio-aws-apigateway/compile
+#  zio-aws-apigatewaymanagementapi/compile zio-aws-apigatewayv2/compile zio-aws-appconfig/compile
+#  zio-aws-applicationautoscaling/compile zio-aws-applicationdiscovery/compile zio-aws-applicationinsights/compile
+#  zio-aws-appmesh/compile zio-aws-appstream/compile zio-aws-appsync/compile zio-aws-athena/compile
+#  zio-aws-autoscaling/compile zio-aws-autoscalingplans/compile zio-aws-backup/compile
+#  zio-aws-batch/compile zio-aws-braket/compile zio-aws-budgets/compile zio-aws-chime/compile
+#  zio-aws-cloud9/compile zio-aws-clouddirectory/compile zio-aws-cloudformation/compile
+#  zio-aws-cloudfront/compile zio-aws-cloudhsm/compile zio-aws-cloudhsmv2/compile"
+- COMMANDS="clean zio-aws-xray/compile zio-aws-xray/publish zio-aws-acm/compile zio-aws-acmpca/compile
   zio-aws-alexaforbusiness/compile zio-aws-amplify/compile zio-aws-apigateway/compile
   zio-aws-apigatewaymanagementapi/compile zio-aws-apigatewayv2/compile zio-aws-appconfig/compile
   zio-aws-applicationautoscaling/compile zio-aws-applicationdiscovery/compile zio-aws-applicationinsights/compile

--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
-enablePlugins(Common, ZioAwsCodegenPlugin)
+enablePlugins(Common, ZioAwsCodegenPlugin, GitVersioning)
 
 ThisBuild / travisParallelJobs := 8
 ThisBuild / travisSource := file(".travis.base.yml")
 ThisBuild / travisTarget := file(".travis.yml")
 
 lazy val root = Project("zio-aws", file(".")).settings(
-  publishArtifact := false,
-) aggregate(core, http4s, netty, akkahttp)
+  publishArtifact := false
+) aggregate (core, http4s, netty, akkahttp)
 
 lazy val core = Project("zio-aws-core", file("zio-aws-core"))
   .settings(
@@ -16,42 +16,47 @@ lazy val core = Project("zio-aws-core", file("zio-aws-core"))
       "dev.zio" %% "zio-streams" % zioVersion,
       "dev.zio" %% "zio-interop-reactivestreams" % zioReactiveStreamsInteropVersion,
       "org.scala-lang.modules" %% "scala-collection-compat" % "2.2.0",
-
       "dev.zio" %% "zio-test" % zioVersion % "test",
-      "dev.zio" %% "zio-test-sbt" % zioVersion % "test",
+      "dev.zio" %% "zio-test-sbt" % zioVersion % "test"
     ),
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
   )
 
-lazy val http4s = Project("zio-aws-http4s", file("zio-aws-http4s")).settings(
-  libraryDependencies ++= Seq(
-    "org.http4s" %% "http4s-dsl" % http4sVersion,
-    "org.http4s" %% "http4s-blaze-client" % http4sVersion,
-    "software.amazon.awssdk" % "http-client-spi" % awsVersion,
-    "dev.zio" %% "zio" % zioVersion,
-    "dev.zio" %% "zio-interop-cats" % zioCatsInteropVersion,
-    "co.fs2" %% "fs2-reactive-streams" % fs2Version,
-    "org.typelevel" %% "cats-effect" % catsEffectVersion,
-    "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1",
+lazy val http4s = Project("zio-aws-http4s", file("zio-aws-http4s"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "org.http4s" %% "http4s-dsl" % http4sVersion,
+      "org.http4s" %% "http4s-blaze-client" % http4sVersion,
+      "software.amazon.awssdk" % "http-client-spi" % awsVersion,
+      "dev.zio" %% "zio" % zioVersion,
+      "dev.zio" %% "zio-interop-cats" % zioCatsInteropVersion,
+      "co.fs2" %% "fs2-reactive-streams" % fs2Version,
+      "org.typelevel" %% "cats-effect" % catsEffectVersion,
+      "org.scala-lang.modules" %% "scala-java8-compat" % "0.9.1"
+    )
   )
-).dependsOn(core)
+  .dependsOn(core)
 
-lazy val akkahttp = Project("zio-aws-akka-http", file("zio-aws-akka-http")).settings(
-  libraryDependencies ++= Seq(
-    "com.typesafe.akka" %% "akka-stream" % "2.6.10",
-    "com.typesafe.akka" %% "akka-http" % "10.2.1",
-    "com.github.matsluni" %% "aws-spi-akka-http" % "0.0.10",
+lazy val akkahttp = Project("zio-aws-akka-http", file("zio-aws-akka-http"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "com.typesafe.akka" %% "akka-stream" % "2.6.10",
+      "com.typesafe.akka" %% "akka-http" % "10.2.1",
+      "com.github.matsluni" %% "aws-spi-akka-http" % "0.0.10"
+    )
   )
-).dependsOn(core)
+  .dependsOn(core)
 
-lazy val netty = Project("zio-aws-netty", file("zio-aws-netty")).settings(
-  libraryDependencies ++= Seq(
-    "software.amazon.awssdk" % "netty-nio-client" % awsVersion,
+lazy val netty = Project("zio-aws-netty", file("zio-aws-netty"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "software.amazon.awssdk" % "netty-nio-client" % awsVersion
+    )
   )
-).dependsOn(core)
+  .dependsOn(core)
 
 lazy val examples = Project("examples", file("examples")).settings(
-  publishArtifact := false,
+  publishArtifact := false
 ) aggregate (example1)
 
 lazy val example1 = Project("example1", file("examples") / "example1")
@@ -63,23 +68,24 @@ lazy val example1 = Project("example1", file("examples") / "example1")
     LocalProject("zio-aws-ec2")
   )
 
-lazy val integtests = Project("integtests", file("integtests")).settings(
-  libraryDependencies ++= Seq(
-    "dev.zio" %% "zio" % "1.0.1",
-    "dev.zio" %% "zio-test" % "1.0.1",
-    "dev.zio" %% "zio-test-sbt" % "1.0.1",
-
-    "org.apache.logging.log4j" % "log4j-1.2-api" % "2.13.3",
-    "org.apache.logging.log4j" % "log4j-core" % "2.13.3",
-    "org.apache.logging.log4j" % "log4j-api" % "2.13.3",
-    "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.13.3",
-  ),
-  testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
-).dependsOn(
-  core,
-  http4s,
-  netty,
-  akkahttp,
-  LocalProject("zio-aws-s3"),
-  LocalProject("zio-aws-dynamodb")
-)
+lazy val integtests = Project("integtests", file("integtests"))
+  .settings(
+    libraryDependencies ++= Seq(
+      "dev.zio" %% "zio" % "1.0.1",
+      "dev.zio" %% "zio-test" % "1.0.1",
+      "dev.zio" %% "zio-test-sbt" % "1.0.1",
+      "org.apache.logging.log4j" % "log4j-1.2-api" % "2.13.3",
+      "org.apache.logging.log4j" % "log4j-core" % "2.13.3",
+      "org.apache.logging.log4j" % "log4j-api" % "2.13.3",
+      "org.apache.logging.log4j" % "log4j-slf4j-impl" % "2.13.3"
+    ),
+    testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework")
+  )
+  .dependsOn(
+    core,
+    http4s,
+    netty,
+    akkahttp,
+    LocalProject("zio-aws-s3"),
+    LocalProject("zio-aws-dynamodb")
+  )

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,4 +1,3 @@
-
 import io.github.vigoo.zioaws.codegen.ZioAwsCodegenPlugin.autoImport._
 import sbt._
 import Keys._
@@ -34,49 +33,48 @@ object Common extends AutoPlugin {
 
   override val trigger = allRequirements
 
-  override val requires = Sonatype
+  override val requires = Sonatype && ci.release.early.Plugin
 
   override lazy val projectSettings =
     Seq(
       scalaVersion := scala213Version,
       crossScalaVersions := List(scala212Version, scala213Version),
-
       organization := "io.github.vigoo",
       version := zioAwsVersion,
-
       awsLibraryVersion := awsVersion,
-
       scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 12)) => scalacOptions212
         case Some((2, 13)) => scalacOptions213
-        case _ => Nil
+        case _             => Nil
       }),
-
       // Publishing
       publishMavenStyle := true,
-
       description := "Low-level AWS wrapper for ZIO",
-      licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")),
-
-      developers := List(
-        Developer(id = "vigoo", name = "Daniel Vigovszky", email = "daniel.vigovszky@gmail.com", url = url("https://vigoo.github.io"))
+      licenses := Seq(
+        "APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")
       ),
-
+      developers := List(
+        Developer(
+          id = "vigoo",
+          name = "Daniel Vigovszky",
+          email = "daniel.vigovszky@gmail.com",
+          url = url("https://vigoo.github.io")
+        )
+      ),
       publishTo := sonatypePublishToBundle.value,
       sonatypeTimeoutMillis := 300 * 60 * 1000,
-
-      sonatypeProjectHosting := Some(GitHubHosting("vigoo", "zio-aws", "daniel.vigovszky@gmail.com")),
-
+      sonatypeProjectHosting := Some(
+        GitHubHosting("vigoo", "zio-aws", "daniel.vigovszky@gmail.com")
+      ),
       credentials ++=
         (for {
           username <- Option(System.getenv().get("SONATYPE_USERNAME"))
           password <- Option(System.getenv().get("SONATYPE_PASSWORD"))
-        } yield
-          Credentials(
-            "Sonatype Nexus Repository Manager",
-            "oss.sonatype.org",
-            username,
-            password)).toSeq,
-
+        } yield Credentials(
+          "Sonatype Nexus Repository Manager",
+          "oss.sonatype.org",
+          username,
+          password
+        )).toSeq
     )
 }

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -40,7 +40,6 @@ object Common extends AutoPlugin {
       scalaVersion := scala213Version,
       crossScalaVersions := List(scala212Version, scala213Version),
       organization := "io.github.vigoo",
-      version := zioAwsVersion,
       awsLibraryVersion := awsVersion,
       scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 12)) => scalacOptions212

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.2.4")
 
 // Codegen project
 
@@ -9,4 +10,3 @@ val awsVersion = "2.14.3"
 lazy val codegen = project
   .in(file("."))
   .dependsOn(ProjectRef(file("../zio-aws-codegen"), "zio-aws-codegen"))
-

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,2 +1,1 @@
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.2.4", "1.0", "2.12")

--- a/zio-aws-codegen/build.sbt
+++ b/zio-aws-codegen/build.sbt
@@ -7,12 +7,11 @@ scalacOptions := Seq("-Ypartial-unification", "-deprecation")
 libraryDependencies ++= Seq(
   "dev.zio" %% "zio" % zioVersion,
   "dev.zio" %% "zio-nio" % "1.0.0-RC9",
-
   "io.circe" %% "circe-yaml" % "0.13.1",
-
   "software.amazon.awssdk" % "codegen" % awsVersion,
   "software.amazon.awssdk" % "aws-sdk-java" % awsVersion,
-
   "org.scalameta" %% "scalameta" % "4.3.21",
   "com.lihaoyi" %% "os-lib" % "0.7.1"
 )
+
+addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.2.4")

--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/ZioAwsCodegenPlugin.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/ZioAwsCodegenPlugin.scala
@@ -9,7 +9,6 @@ import zio._
 import zio.nio.core.file.Path
 
 object ZioAwsCodegenPlugin extends AutoPlugin {
-
   object autoImport {
     val awsLibraryId =
       settingKey[String]("Selects the AWS library to generate sources for")
@@ -160,6 +159,7 @@ object ZioAwsCodegenPlugin extends AutoPlugin {
             Compile / sourceGenerators += generateSources.taskValue,
           )
           .dependsOn(deps: _*)
+          .enablePlugins(ci.release.early.Plugin)
 
         mapping.updated(id, project)
       }

--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/ZioAwsCodegenPlugin.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/ZioAwsCodegenPlugin.scala
@@ -156,7 +156,7 @@ object ZioAwsCodegenPlugin extends AutoPlugin {
           .settings(
             libraryDependencies += "software.amazon.awssdk" % id.name % awsLibraryVersion.value,
             awsLibraryId := id.toString,
-            Compile / sourceGenerators += generateSources.taskValue,
+            Compile / sourceGenerators += generateSources.taskValue
           )
           .dependsOn(deps: _*)
           .enablePlugins(ci.release.early.Plugin)

--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/ZioAwsCodegenPlugin.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/ZioAwsCodegenPlugin.scala
@@ -158,10 +158,6 @@ object ZioAwsCodegenPlugin extends AutoPlugin {
             libraryDependencies += "software.amazon.awssdk" % id.name % awsLibraryVersion.value,
             awsLibraryId := id.toString,
             Compile / sourceGenerators += generateSources.taskValue,
-            addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8"),
-            addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0"),
-            addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0"),
-            addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.2.4")
           )
           .dependsOn(deps: _*)
 

--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/ZioAwsCodegenPlugin.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/ZioAwsCodegenPlugin.scala
@@ -11,9 +11,13 @@ import zio.nio.core.file.Path
 object ZioAwsCodegenPlugin extends AutoPlugin {
 
   object autoImport {
-    val awsLibraryId = settingKey[String]("Selects the AWS library to generate sources for")
-    val awsLibraryVersion = settingKey[String]("Specifies the version of the  AWS Java SDK to depend on")
-    val travisParallelJobs = settingKey[Int]("Number of parallel jobs in the generated travis file")
+    val awsLibraryId =
+      settingKey[String]("Selects the AWS library to generate sources for")
+    val awsLibraryVersion = settingKey[String](
+      "Specifies the version of the  AWS Java SDK to depend on"
+    )
+    val travisParallelJobs =
+      settingKey[Int]("Number of parallel jobs in the generated travis file")
     val travisSource = settingKey[File]("Travis source file")
     val travisTarget = settingKey[File]("Travis target file")
 
@@ -26,7 +30,7 @@ object ZioAwsCodegenPlugin extends AutoPlugin {
         val idStr = awsLibraryId.value
         val id = ModelId.parse(idStr) match {
           case Left(failure) => sys.error(failure)
-          case Right(value) => value
+          case Right(value)  => value
         }
 
         val targetRoot = (sourceManaged in Compile).value
@@ -51,12 +55,13 @@ object ZioAwsCodegenPlugin extends AutoPlugin {
               files <- generator.generateServiceCode(id, model)
             } yield files.toSeq
           task.provideCustomLayer(env).catchAll { generatorError =>
-            ZIO.effect(log.error(s"Code generator failure: ${generatorError}")).as(Seq.empty)
+            ZIO
+              .effect(log.error(s"Code generator failure: ${generatorError}"))
+              .as(Seq.empty)
           }
         }
       }
   }
-
 
   import autoImport._
 
@@ -78,7 +83,9 @@ object ZioAwsCodegenPlugin extends AutoPlugin {
       } yield generateSbtSubprojects(ids)
 
       task.provideCustomLayer(env).catchAll { generatorError =>
-        zio.console.putStrLnErr(s"Code generator failure: ${generatorError}").as(Seq.empty)
+        zio.console
+          .putStrLnErr(s"Code generator failure: ${generatorError}")
+          .as(Seq.empty)
       }
     }
   }
@@ -108,33 +115,40 @@ object ZioAwsCodegenPlugin extends AutoPlugin {
           _ <- generator.generateTravisYaml(ids)
         } yield ()
       task.provideCustomLayer(env).catchAll { generatorError =>
-        ZIO.effect(log.error(s"Code generator failure: ${generatorError}")).as(Seq.empty)
+        ZIO
+          .effect(log.error(s"Code generator failure: ${generatorError}"))
+          .as(Seq.empty)
       }
     }
   }
 
   protected def generateSbtSubprojects(ids: Set[ModelId]): Seq[Project] = {
-    val map = ids
-      .toSeq
-      .sortWith { case (a, b) =>
-        val aIsDependent = a.subModuleName match {
-          case Some(value) if value != a.name => true
-          case _ => false
-        }
-        val bIsDependent = b.subModuleName match {
-          case Some(value) if value != b.name => true
-          case _ => false
-        }
+    val map = ids.toSeq
+      .sortWith {
+        case (a, b) =>
+          val aIsDependent = a.subModuleName match {
+            case Some(value) if value != a.name => true
+            case _                              => false
+          }
+          val bIsDependent = b.subModuleName match {
+            case Some(value) if value != b.name => true
+            case _                              => false
+          }
 
-        bIsDependent || (!aIsDependent && a.toString < b.toString)
+          bIsDependent || (!aIsDependent && a.toString < b.toString)
       }
       .foldLeft(Map.empty[ModelId, Project]) { (mapping, id) =>
         val name = id.moduleName
         val fullName = s"zio-aws-$name"
         val deps: Seq[ClasspathDep[ProjectReference]] = id.subModule match {
           case Some(value) if value != id.name =>
-            Seq(ClasspathDependency(LocalProject("zio-aws-core"), None),
-              ClasspathDependency(mapping(ModelId(id.name, Some(id.name))), None))
+            Seq(
+              ClasspathDependency(LocalProject("zio-aws-core"), None),
+              ClasspathDependency(
+                mapping(ModelId(id.name, Some(id.name))),
+                None
+              )
+            )
           case _ =>
             Seq(ClasspathDependency(LocalProject("zio-aws-core"), None))
         }
@@ -143,7 +157,12 @@ object ZioAwsCodegenPlugin extends AutoPlugin {
           .settings(
             libraryDependencies += "software.amazon.awssdk" % id.name % awsLibraryVersion.value,
             awsLibraryId := id.toString,
-            Compile / sourceGenerators += generateSources.taskValue)
+            Compile / sourceGenerators += generateSources.taskValue,
+            addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8"),
+            addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0"),
+            addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0"),
+            addSbtPlugin("io.shiftleft" % "sbt-ci-release-early" % "1.2.4")
+          )
           .dependsOn(deps: _*)
 
         mapping.updated(id, project)
@@ -152,7 +171,7 @@ object ZioAwsCodegenPlugin extends AutoPlugin {
     val projects = map.values.toSeq
     val aggregated = Project("all", file("generated") / "all")
       .settings(
-        publishArtifact := false,
+        publishArtifact := false
       )
       .aggregate(projects.map(projectToRef): _*)
 

--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/TravisYamlGenerator.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/TravisYamlGenerator.scala
@@ -12,7 +12,7 @@ trait TravisYamlGenerator {
     val sortedProjectNames = ids.map(id => s"zio-aws-${id.moduleName}").toList.sorted
     val grouped = sortedProjectNames.grouped(Math.ceil(ids.size.toDouble / parallelJobs.toDouble).toInt)
     val envDefs = grouped.map(group =>
-    s"""COMMANDS="clean ${group.map(name => s"$name/compile").mkString(" ")}""""
+    s"""COMMANDS="clean ${group.map(name => s"$name/compile").mkString(" ")} ${group.map(name => s"$name/ciReleaseSonatype").mkString(" ")}""""
     ).toVector
 
     source.deepMerge(Json.obj(

--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/TravisYamlGenerator.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/TravisYamlGenerator.scala
@@ -12,7 +12,7 @@ trait TravisYamlGenerator {
     val sortedProjectNames = ids.map(id => s"zio-aws-${id.moduleName}").toList.sorted
     val grouped = sortedProjectNames.grouped(Math.ceil(ids.size.toDouble / parallelJobs.toDouble).toInt)
     val envDefs = grouped.map(group =>
-    s"""COMMANDS="clean ${group.map(name => s"$name/compile").mkString(" ")} ${group.map(name => s"$name/ciReleaseSonatype").mkString(" ")}""""
+    s"""COMMANDS="clean ${group.map(name => s"$name/compile").mkString(" ")} ${group.map(name => s"$name/publishSigned").mkString(" ")}""""
     ).toVector
 
     source.deepMerge(Json.obj(


### PR DESCRIPTION
Work in progress for automatic release.

The way this should work is:
* SBT plugin `sbt-ci-early-release` is added to all generated projects
* Version numbering would become independent of the AWS SDK version, but based on we the number of commits since the latest git tag.
* Upon build, the release would be tagged
* Travis YML will contain 

Currently stuck on adding the early-release plugin to subprojects. SBT is looking for the scala 2.13 version of the plugin and it's dependencies, but all SBT plugins are scala 2.12.

Initial setup would consist of:
* Configuring Sonatype credentials in Travis
* Making an initial version tag

Would be cool:
* Automatic release notes on Github 