### PR TITLE
Unpack inner exceptions

### DIFF
--- a/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/AwsError.scala
+++ b/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/AwsError.scala
@@ -2,7 +2,6 @@ package io.github.vigoo.zioaws.core
 
 import java.util.concurrent.CompletionException
 
-import software.amazon.awssdk.core.exception.SdkException
 import zio.ZIO
 
 sealed trait AwsError {

--- a/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/AwsError.scala
+++ b/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/AwsError.scala
@@ -22,8 +22,6 @@ object AwsError {
     val innerReason = reason match {
       case e: CompletionException =>
         Option(e.getCause).getOrElse(e)
-      case e: SdkException        =>
-        Option(e.getCause).getOrElse(e)
       case e => e
     }
 


### PR DESCRIPTION
* Various AWS SDK methods throw a `SdkException` that wraps an inner exception.
* CompletionStage-based methods can fail with a `CompletionException` which just wraps the inner exception.