### PR TITLE
Fix for streaming output methods

### DIFF
--- a/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/AwsServiceBase.scala
+++ b/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/AwsServiceBase.scala
@@ -244,9 +244,9 @@ trait AwsServiceBase[R, Self[_]] {
         runtime <- ZIO.runtime[Any]
         publisherPromise <- Promise.make[AwsError, Publisher[EventI]]
         responsePromise <- Promise.make[AwsError, Response]
-        signalQueue <- ZQueue.bounded[Option[AwsError]](16)
+        signalQueue <- ZQueue.bounded[AwsError](16)
 
-        _ <- aspect(
+        subscribe = aspect(
           ZIO
             .fromCompletionStage(
               impl(
@@ -263,9 +263,16 @@ trait AwsServiceBase[R, Self[_]] {
             )
             .mapError(AwsError.fromThrowable) ? (serviceName / opName)
         ).unwrap
-        _ <- responsePromise.await
+        /*
+        Not all SDK methods complete on success via the completion stage, for example kinesis subscribeToShard, for
+        which the publisherPromise completes first. Subscribe can complete with failures. Just to be sure, we
+        await several effects for the first success or failure.
+         */
+        _ <- subscribe raceFirst
+          responsePromise.await raceFirst
+          signalQueue.take.flip raceFirst
+          publisherPromise.await
         publisher <- publisherPromise.await
-
         stream =
           publisher
             .toStream()
@@ -277,8 +284,7 @@ trait AwsServiceBase[R, Self[_]] {
             .map(_.swap)
             .takeUntil(_.isLeft)
             .flatMap {
-              case Left(None)         => ZStream.empty
-              case Left(Some(error))  => ZStream.fail(error)
+              case Left(error)        => ZStream.fail(error)
               case Right(item: Event) => ZStream.succeed(item)
               case Right(_)           => ZStream.empty
             }
@@ -328,7 +334,7 @@ trait AwsServiceBase[R, Self[_]] {
         runtime <- ZIO.runtime[Any]
         outPublisherPromise <- Promise.make[AwsError, Publisher[OutEventI]]
         responsePromise <- Promise.make[AwsError, Response]
-        signalQueue <- ZQueue.bounded[Option[AwsError]](16)
+        signalQueue <- ZQueue.bounded[AwsError](16)
 
         _ <- aspect(
           ZIO
@@ -360,8 +366,7 @@ trait AwsServiceBase[R, Self[_]] {
             .map(_.swap)
             .takeUntil(_.isLeft)
             .flatMap {
-              case Left(None)            => ZStream.empty
-              case Left(Some(error))     => ZStream.fail(error)
+              case Left(error)           => ZStream.fail(error)
               case Right(item: OutEvent) => ZStream.succeed(item)
               case Right(_)              => ZStream.empty
             }

--- a/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/ZEventStreamResponseHandler.scala
+++ b/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/ZEventStreamResponseHandler.scala
@@ -9,7 +9,7 @@ import zio.stream.ZStream
 object ZEventStreamResponseHandler {
   def create[ResponseT, EventT](
       runtime: Runtime[Any],
-      signalQueue: Queue[Option[AwsError]],
+      signalQueue: Queue[AwsError],
       responsePromise: Promise[AwsError, ResponseT],
       promise: Promise[AwsError, Publisher[EventT]]
   ): EventStreamResponseHandler[ResponseT, EventT] =
@@ -22,7 +22,7 @@ object ZEventStreamResponseHandler {
 
       override def exceptionOccurred(throwable: Throwable): Unit =
         runtime.unsafeRun(
-          signalQueue.offer(Some(AwsError.fromThrowable(throwable)))
+          signalQueue.offer(AwsError.fromThrowable(throwable))
         )
 
       override def complete(): Unit = {

--- a/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/AwsServiceBaseSpec.scala
+++ b/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/AwsServiceBaseSpec.scala
@@ -520,19 +520,6 @@ object AwsServiceBaseSpec extends DefaultRunnableSpec with Service[Any] {
             ).run
           )(isAwsFailure)
         },
-        testM("exception after stream") {
-          import SimulatedEventStreamResponseHandlerReceiver._
-          assertM(
-            runAsyncRequestEventInputOutputStream(
-              handlerSteps = List(
-                ResponseReceived,
-                EventStream,
-                ReportException(SimulatedException),
-                CompleteFuture
-              )
-            ).run
-          )(isAwsFailure)
-        },
         testM("failed future before stream") {
           import SimulatedEventStreamResponseHandlerReceiver._
           assertM(

--- a/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/AwsServiceBaseSpec.scala
+++ b/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/AwsServiceBaseSpec.scala
@@ -513,7 +513,6 @@ object AwsServiceBaseSpec extends DefaultRunnableSpec with Service[Any] {
           assertM(
             runAsyncRequestEventInputOutputStream(
               handlerSteps = List(
-                ResponseReceived,
                 ReportException(SimulatedException),
                 EventStream,
                 CompleteFuture
@@ -542,18 +541,6 @@ object AwsServiceBaseSpec extends DefaultRunnableSpec with Service[Any] {
                 FailFuture(SimulatedException),
                 ResponseReceived,
                 EventStream
-              )
-            ).run
-          )(isAwsFailure)
-        },
-        testM("failed future after stream") {
-          import SimulatedEventStreamResponseHandlerReceiver._
-          assertM(
-            runAsyncRequestEventInputOutputStream(
-              handlerSteps = List(
-                ResponseReceived,
-                EventStream,
-                FailFuture(SimulatedException)
               )
             ).run
           )(isAwsFailure)

--- a/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/AwsServiceBaseSpec.scala
+++ b/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/AwsServiceBaseSpec.scala
@@ -409,18 +409,6 @@ object AwsServiceBaseSpec extends DefaultRunnableSpec with Service[Any] {
             ).run
           )(isAwsFailure)
         },
-        testM("failed future after stream") {
-          import SimulatedEventStreamResponseHandlerReceiver._
-          assertM(
-            runAsyncRequestEventOutputStream(
-              handlerSteps = List(
-                ResponseReceived,
-                EventStream,
-                FailFuture(SimulatedException)
-              )
-            ).run
-          )(isAwsFailure)
-        },
         testM("publisher fail before subscribe")(
           assertM(
             runAsyncRequestEventOutputStream(


### PR DESCRIPTION
This fixes an issue with read timeouts on kinesis `subscribeToShard` and maybe other similar methods. See the comment in the code.
 
Also simplify the signalQueue for `ZEventStreamResponseHandler`