### PR TITLE
Do not map Integer type alias to boxed integer

### DIFF
--- a/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/TypeMapping.scala
+++ b/zio-aws-codegen/src/main/scala/io/github/vigoo/zioaws/codegen/generator/TypeMapping.scala
@@ -25,7 +25,6 @@ object TypeMapping {
     "String",
     "Boolean",
     "Int",
-    "Integer",
     "Long",
     "Float",
     "Double",


### PR DESCRIPTION
In `zio-aws-sqs` for example, an `Int` type alias is defined with the name `Integer`. It was treated as a built-in incorrectly, leading to using the boxed Java `Integer` for this type instead of Scala `Int`