### PR TITLE
Provides an alternative fix for event output streaming 

### DIFF
--- a/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/ZEventStreamResponseHandler.scala
+++ b/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/ZEventStreamResponseHandler.scala
@@ -21,9 +21,10 @@ object ZEventStreamResponseHandler {
         runtime.unsafeRun(promise.succeed(publisher))
 
       override def exceptionOccurred(throwable: Throwable): Unit =
-        runtime.unsafeRun(
-          signalQueue.offer(AwsError.fromThrowable(throwable))
-        )
+        runtime.unsafeRun {
+          val error = AwsError.fromThrowable(throwable)
+          signalQueue.offerAll(Seq(error, error))
+        }
 
       override def complete(): Unit = {
         // We cannot signal termination here because the publisher stream may still have buffered items.

--- a/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/sim/SimulatedPublisher.scala
+++ b/zio-aws-core/src/test/scala/io/github/vigoo/zioaws/core/sim/SimulatedPublisher.scala
@@ -145,6 +145,7 @@ object SimulatedPublisher {
               for (_ <- 0 until toEmit) {
                 val i = idx.getAndIncrement()
 
+                Thread.sleep(100) // slow publishing to enable verification of emitting errors in parallel to the publisher
                 wrapped.onNext(convert(in(i)))
 
               }


### PR DESCRIPTION
without completing the future, with readded and new tests

This should fix #127 

The fix in #115 required some failure case tests to be removed, and it made some other ones flaky due to the `raceFirst` in the new implementation. Even though these tests _may_ simulate cases that never happen with the real AWS SDK it's hard to be sure and I feel more confident by this new implementation that allowed me to readd the few deleted tests cases while it still provides the fix for the issue with kinesis. A new test case guarantees that that tests that the output stream runs even if the underlying implementation never completes the future.
