### PR TITLE
Support for defining dual HTTP/1.1 & HTTP/2 HttpClient layers

### DIFF
--- a/zio-aws-akka-http/src/main/scala/io/github/vigoo/zioaws/akkahttp/package.scala
+++ b/zio-aws-akka-http/src/main/scala/io/github/vigoo/zioaws/akkahttp/package.scala
@@ -4,9 +4,12 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.settings.ConnectionPoolSettings
 import com.github.matsluni.akkahttpspi.AkkaHttpClient
 import io.github.vigoo.zioaws.core.BuilderHelper
-import io.github.vigoo.zioaws.core.httpclient.HttpClient
+import io.github.vigoo.zioaws.core.httpclient.{
+  HttpClient,
+  ServiceHttpCapabilities
+}
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient
-import zio.{Has, ZIO, ZLayer, ZManaged}
+import zio.{Has, ZIO, ZLayer, ZManaged, Task}
 
 import scala.concurrent.ExecutionContext
 
@@ -35,7 +38,9 @@ package object akkahttp {
         )
         .map { akkaClient =>
           new HttpClient.Service {
-            override val client: SdkAsyncHttpClient = akkaClient
+            override def clientFor(
+                serviceCaps: ServiceHttpCapabilities
+            ): Task[SdkAsyncHttpClient] = Task.succeed(akkaClient)
           }
         }
     }

--- a/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/config/package.scala
+++ b/zio-aws-core/src/main/scala/io/github/vigoo/zioaws/core/config/package.scala
@@ -2,7 +2,10 @@ package io.github.vigoo.zioaws.core
 
 import java.net.URI
 
-import io.github.vigoo.zioaws.core.httpclient.HttpClient
+import io.github.vigoo.zioaws.core.httpclient.{
+  HttpClient,
+  ServiceHttpCapabilities
+}
 import software.amazon.awssdk.auth.credentials._
 import software.amazon.awssdk.awscore.client.builder.{
   AwsAsyncClientBuilder,
@@ -45,7 +48,7 @@ package object config {
       def configureHttpClient[
           Client,
           Builder <: AwsAsyncClientBuilder[Builder, Client]
-      ](builder: Builder): Task[Builder]
+      ](builder: Builder, serviceCaps: ServiceHttpCapabilities): Task[Builder]
     }
 
   }
@@ -85,8 +88,11 @@ package object config {
         override def configureHttpClient[
             Client,
             Builder <: AwsAsyncClientBuilder[Builder, Client]
-        ](builder: Builder): Task[Builder] =
-          ZIO.succeed(builder.httpClient(httpClient.client))
+        ](
+            builder: Builder,
+            serviceCaps: ServiceHttpCapabilities
+        ): Task[Builder] =
+          httpClient.clientFor(serviceCaps).map(builder.httpClient)
       }
     }
 
@@ -166,8 +172,11 @@ package object config {
             override def configureHttpClient[
                 Client,
                 Builder <: AwsAsyncClientBuilder[Builder, Client]
-            ](builder: Builder): Task[Builder] =
-              ZIO.succeed(builder.httpClient(httpClient.client))
+            ](
+                builder: Builder,
+                serviceCaps: ServiceHttpCapabilities
+            ): Task[Builder] =
+              httpClient.clientFor(serviceCaps).map(builder.httpClient)
           }
       }
 

--- a/zio-aws-http4s/src/main/scala/io/github/vigoo/zioaws/http4s/package.scala
+++ b/zio-aws-http4s/src/main/scala/io/github/vigoo/zioaws/http4s/package.scala
@@ -4,7 +4,10 @@ import java.net.SocketOption
 import java.nio.channels.AsynchronousChannelGroup
 
 import io.github.vigoo.zioaws.core.httpclient
-import io.github.vigoo.zioaws.core.httpclient.HttpClient
+import io.github.vigoo.zioaws.core.httpclient.{
+  HttpClient,
+  ServiceHttpCapabilities
+}
 import io.github.vigoo.zioaws.core.httpclient.descriptors.channelOptions
 import javax.net.ssl.SSLContext
 import org.http4s.blaze.channel.{ChannelOptions, OptionValue}
@@ -31,7 +34,9 @@ package object http4s {
         .toManaged
         .map { c =>
           new HttpClient.Service {
-            override val client: SdkAsyncHttpClient = c
+            override def clientFor(
+                serviceCaps: ServiceHttpCapabilities
+            ): Task[SdkAsyncHttpClient] = Task.succeed(c)
           }
         }
     }.toLayer
@@ -102,7 +107,9 @@ package object http4s {
           .toManaged
           .map { c =>
             new HttpClient.Service {
-              override val client: SdkAsyncHttpClient = c
+              override def clientFor(
+                  serviceCaps: ServiceHttpCapabilities
+              ): Task[SdkAsyncHttpClient] = Task.succeed(c)
             }
           }
       }


### PR DESCRIPTION
Solves https://github.com/vigoo/zio-aws/issues/109 in a similar way as @svroonland in `zio-kinesis` but being part of `zio-aws-core` its more reusable.

My understanding is that only `kinesis` and `transcribestreaming` support HTTP/2 at the moment, this _may_ be extractable from the schema (there is a metadata field that I think represents that) but I'll do that separately, for now http2 support is hardcoded for these two.

The idea is that there is a new `Dual` protocol setting that can be set for the `HttpClient` layer, in this case it creates two different http layers with for the two different protocols, and can be fed to any `zio-aws` service layer as they know if they support HTTP/2 or not. 

The http4s and akka-http backends does not support HTTP/2 for now.