### PR TITLE
Fix resource realease in Http4sClient

### DIFF
--- a/integtests/src/test/scala/zio/aws/integtests/DynamoDbTests.scala
+++ b/integtests/src/test/scala/zio/aws/integtests/DynamoDbTests.scala
@@ -177,7 +177,7 @@ object DynamoDbTests extends DefaultRunnableSpec with Logging {
       ).provideCustomLayer(
         ((Clock.any ++ Console.any ++ (http4sClient >>> awsConfig)) >>> dynamoDb)
           .mapError(TestFailure.die)
-      ) @@ ignore @@ sequential,
+      ) @@ sequential,
       suite("with akka-http")(
         tests("akkahttp"): _*
       ).provideCustomLayer(

--- a/integtests/src/test/scala/zio/aws/integtests/S3Tests.scala
+++ b/integtests/src/test/scala/zio/aws/integtests/S3Tests.scala
@@ -143,7 +143,7 @@ object S3Tests extends DefaultRunnableSpec with Logging {
       ).provideCustomLayer(
         ((Clock.any ++ Console.any ++ (http4sClient >>> awsConfig)) >>> s3Client)
           .mapError(TestFailure.die)
-      ) @@ ignore @@ sequential,
+      ) @@ sequential,
       suite("with akka-http")(
         tests("akkahttp", ignoreUpload = true): _*
       ).provideCustomLayer(


### PR DESCRIPTION
The dispatcher created by `toUnicastPublisher` was closed too early before the whole stream was processed.
Closing the resource in the `onFinalizeCase` or `org.reactivestreams.Subscriber#onComplete` doesn't work either.

The only solution that I could think of that worked was to create a long lived dispatcher instead of a short lived one per response.