### PR TITLE
Set content length on `ZStreamAsyncRequestBody`

### DIFF
--- a/zio-aws-core/src/main/scala/zio/aws/core/ZStreamAsyncRequestBody.scala
+++ b/zio-aws-core/src/main/scala/zio/aws/core/ZStreamAsyncRequestBody.scala
@@ -10,10 +10,10 @@ import zio._
 import zio.stream.ZStream
 import zio.interop.reactivestreams._
 
-class ZStreamAsyncRequestBody[R](stream: ZStream[R, AwsError, Byte])(implicit
+class ZStreamAsyncRequestBody[R](stream: ZStream[R, AwsError, Byte], contentLength: Optional[lang.Long])(implicit
     runtime: Runtime[R]
 ) extends AsyncRequestBody {
-  override def contentLength(): Optional[lang.Long] = Optional.empty()
+  override def contentLength(): Optional[lang.Long] = contentLength
 
   override def subscribe(s: Subscriber[_ >: ByteBuffer]): Unit =
     Unsafe.unsafe { implicit u =>


### PR DESCRIPTION
Content length is a required property for S3.putObject. We need to pass it to the `ZStreamAsyncRequestBody` so that it can be used by wrappers such as `AsyncRequestBodyHttpChecksumTrailerInterceptor`.

With this change, the checksumAlgorithm feature of S3.putObject will work as expected.

Fixes https://github.com/zio/zio-aws/issues/1007.

Note: It is not clear to me if this change will break existing usage of AwsServiceBase.asyncRequestInputStream.
There might be cleaner ways to pass content length.