### PR TITLE
Update zio-interop-cats to 23.0.0.4

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -13,7 +13,7 @@ object Common extends AutoPlugin {
   object autoImport {
     val zioVersion = "2.0.10"
     val zioMockVersion = "1.0.0-RC8"
-    val zioCatsInteropVersion = "23.0.03"
+    val zioCatsInteropVersion = "23.0.0.4"
     val zioReactiveStreamsInteropVersion = "2.0.1"
     val zioConfigVersion = "3.0.7"
     val zioPreludeVersion = "1.0.0-RC18"


### PR DESCRIPTION
Addresses this as well: https://github.com/zio/interop-cats/issues/658 where interop-cats 2.0.0.3 was published as 2.0.03. As a result, tooling like Scala Steward will also not bring in 23.0.0.4, since 23.0.03 > 23.0.0.4.