### PR TITLE
Set versionScheme in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,7 @@ ThisBuild / ciParallelJobs := 5
 ThisBuild / ciSeparateJobs := Seq("zio-aws-ec2")
 ThisBuild / ciTarget := file(".github/workflows/ci.yml")
 ThisBuild / artifactListTarget := file("docs/artifacts.md")
+ThisBuild / versionScheme := Some(VersionScheme.PVP)
 
 Global / pgpPublicRing := file("/tmp/public.asc")
 Global / pgpSecretRing := file("/tmp/secret.asc")


### PR DESCRIPTION
Enabling this would allow sbt to automatically fail when libraries using different major versions of zio-aws are getting used.
Note that is going to be breaking a lot of people builds, but on the other hand stop a lot of runtime errors.

PVP should correctly cover your versioning scheme, but pease double check: https://pvp.haskell.org/faq/#:~:text=Another%20important%20difference%20between%20SemVer,without%20requiring%20major%20version%20increment.