### PR TITLE
fix pagination codegen

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -19,7 +19,7 @@ object Common extends AutoPlugin {
     val zioPreludeVersion = "1.0.0-RC40"
     val catsEffectVersion = "3.6.1"
 
-    val awsVersion = "2.31.30"
+    val awsVersion = "2.31.45"
     val awsSubVersion = awsVersion.drop(awsVersion.indexOf('.') + 1)
     val http4sVersion = "0.23.27"
     val blazeVersion = "0.23.17"

--- a/zio-aws-codegen/build.sbt
+++ b/zio-aws-codegen/build.sbt
@@ -1,5 +1,5 @@
 val zioVersion = "2.1.18"
-val awsVersion = "2.31.30"
+val awsVersion = "2.31.45"
 
 sbtPlugin := true
 scalaVersion := "2.12.20"

--- a/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/OperationCollector.scala
+++ b/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/OperationCollector.scala
@@ -383,7 +383,7 @@ object OperationCollector {
   ) = {
     for {
       paginator <- Option(
-        models.paginatorsModel().getPaginatorDefinition(opName)
+        models.paginatorsModel().getPaginatorDefinition(op.getName)
       )
       if paginator.isValid
       key <- Option(paginator.getResultKey).flatMap(_.asScala.headOption)

--- a/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/OperationCollector.scala
+++ b/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/OperationCollector.scala
@@ -203,7 +203,7 @@ object OperationCollector {
                   ZIO.succeed(RequestResponse(paginationDefinition))
               )
             } else {
-              getJavaSdkPaginatorDefinition(opName, op, models) match {
+              getJavaSdkPaginatorDefinition(op, models) match {
                 case Some(createDef) =>
                   // Special paginator with Java SDK support
                   for {
@@ -364,7 +364,7 @@ object OperationCollector {
               )
             } else {
               // Fall back to Java SDK paginator if possible
-              getJavaSdkPaginatorDefinition(opName, op, models) match {
+              getJavaSdkPaginatorDefinition(op, models) match {
                 case Some(definition) =>
                   definition.map(Some(_))
                 case None =>
@@ -377,7 +377,6 @@ object OperationCollector {
   }
 
   private def getJavaSdkPaginatorDefinition(
-      opName: String,
       op: Operation,
       models: C2jModels
   ) = {


### PR DESCRIPTION
builds not passing since aws sdk 2.31.31.
I have looked at the CI logs and the SDK changes and found that the problem is a method that was added to the paginator definition.
The AWS SDK code generation was fine, so I looked at the decision part of the paginator and found that the AWS SDK used Operation#getName.

https://github.com/aws/aws-sdk-java-v2/blob/master/codegen/src/main/java/software/amazon/awssdk/codegen/poet/client/AsyncClientInterface.java#L254
https://github.com/aws/aws-sdk-java-v2/blob/master/codegen/src/main/java/software/amazon/awssdk/codegen/AddOperations.java#L280