### PR TITLE
Try fix release process to new Maven Portal

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -101,7 +101,8 @@ object Common extends AutoPlugin {
         if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
         else localStaging.value
       },
-      ThisBuild / sonaUploadRequestTimeout := 2.hours,
+      Global / excludeLintKeys += sonaUploadRequestTimeout, // avoids noisy useless warnings
+      sonaUploadRequestTimeout := 2.hours,
       credentials ++=
         (for {
           username <- Option(System.getenv().get("SONATYPE_USERNAME"))


### PR DESCRIPTION
Previous attempt failed with a timeout at ~20minutes:
```scala
java.util.concurrent.TimeoutException: Futures timed out after [1215 seconds]
	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:269)
	at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:273)
	at scala.concurrent.Await$.$anonfun$result$1(package.scala:223)
	at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:57)
	at scala.concurrent.Await$.result(package.scala:146)
	at sbt.internal.sona.SonaClient.awaitWithMessage(Sona.scala:174)
	at sbt.internal.sona.SonaClient.uploadBundle(Sona.scala:86)
	at sbt.internal.sona.Sona.uploadBundle(Sona.scala:35)
	at sbt.internal.librarymanagement.Publishing$.sonatypeReleaseAction(Publishing.scala:57)
	at sbt.internal.librarymanagement.Publishing$.$anonfun$sonaRelease$1(Publishing.scala:24)
```

See https://github.com/zio/zio-aws/actions/runs/16110990896/job/45458269962

Previous PRs trying to fix publishing:
- https://github.com/zio/zio-aws/pull/1517
- https://github.com/zio/zio-aws/pull/1532
- https://github.com/zio/zio-aws/pull/1545
- https://github.com/zio/zio-aws/pull/1548
- https://github.com/zio/zio-aws/pull/1554