### PR TITLE
Try fix release process to new Maven Portal

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -102,7 +102,7 @@ object Common extends AutoPlugin {
         else localStaging.value
       },
       Global / excludeLintKeys += sonaUploadRequestTimeout, // avoids noisy useless warnings
-      sonaUploadRequestTimeout := 2.hours,
+      sonaUploadRequestTimeout := 12.hours,
       credentials ++=
         (for {
           username <- Option(System.getenv().get("SONATYPE_USERNAME"))


### PR DESCRIPTION
Previous attempt failed with a timeout after ~4hours:
```scala
java.util.concurrent.TimeoutException: Futures timed out after [14415 seconds]
	at scala.concurrent.impl.Promise$DefaultPromise.ready(Promise.scala:269)
	at scala.concurrent.impl.Promise$DefaultPromise.result(Promise.scala:273)
	at scala.concurrent.Await$.$anonfun$result$1(package.scala:223)
	at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:57)
	at scala.concurrent.Await$.result(package.scala:146)
	at sbt.internal.sona.SonaClient.awaitWithMessage(Sona.scala:174)
	at sbt.internal.sona.SonaClient.uploadBundle(Sona.scala:86)
	at sbt.internal.sona.Sona.uploadBundle(Sona.scala:35)
```
See: https://github.com/zio/zio-aws/actions/runs/16132246479/job/45523749995


Previous PRs trying to fix publishing:
- https://github.com/zio/zio-aws/pull/1517
- https://github.com/zio/zio-aws/pull/1532
- https://github.com/zio/zio-aws/pull/1545
- https://github.com/zio/zio-aws/pull/1548
- https://github.com/zio/zio-aws/pull/1554
- https://github.com/zio/zio-aws/pull/1555