### PR TITLE
Fix unintentional repeat in callDuration aspect

### DIFF
--- a/zio-aws-core/src/main/scala/zio/aws/core/aspects/package.scala
+++ b/zio-aws-core/src/main/scala/zio/aws/core/aspects/package.scala
@@ -50,7 +50,7 @@ package object aspects {
             .tagged("aws_service", r.description.service)
             .tagged("aws_operation", r.description.operation)
             .update(durationInSeconds)
-            .zipRight(f)
+            .as(r)
         }
       }
     }


### PR DESCRIPTION
This fixes unintentional repeat of the main effect in `callDuration` aspect, which results in duplicated requests to AWS, when this aspect is used.