### PR TITLE
fix compilation error with AWS SDK version 2.33.5 and later

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -16,7 +16,7 @@ object Common extends AutoPlugin {
     val zioPreludeVersion = "1.0.0-RC41"
     val catsEffectVersion = "3.6.3"
 
-    val awsVersion = "2.33.4"
+    val awsVersion = "2.33.9"
     val awsSubVersion = awsVersion.drop(awsVersion.indexOf('.') + 1)
     val http4sVersion = "0.23.27"
     val blazeVersion = "0.23.17"

--- a/zio-aws-codegen/build.sbt
+++ b/zio-aws-codegen/build.sbt
@@ -1,5 +1,5 @@
 val zioVersion = "2.1.21"
-val awsVersion = "2.33.4"
+val awsVersion = "2.33.9"
 
 sbtPlugin := true
 scalaVersion := "2.12.20"

--- a/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/ModelCollector.scala
+++ b/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/ModelCollector.scala
@@ -355,6 +355,12 @@ object ModelCollector {
       case None                   => shapeName
     }
 
+    models.customizationConfig().getShapeSubstitutions
+      .asScala
+      .get(shapeName)
+      .flatMap(shapeSubstitution => Option(shapeSubstitution.getEmitAsType))
+      .foreach(typ => shape.setType(typ))
+
     val className = namingStrategy.getShapeClassName(finalName)
     val isPrimitive = isPrimitiveType(shape) && !isBuiltIn(shapeName)
 

--- a/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/ModelCollector.scala
+++ b/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/ModelCollector.scala
@@ -355,8 +355,9 @@ object ModelCollector {
       case None                   => shapeName
     }
 
-    models.customizationConfig().getShapeSubstitutions
-      .asScala
+    Option(models.customizationConfig().getShapeSubstitutions)
+      .map(_.asScala)
+      .getOrElse(Map.empty[String, ShapeSubstitution])
       .get(shapeName)
       .flatMap(shapeSubstitution => Option(shapeSubstitution.getEmitAsType))
       .foreach(typ => shape.setType(typ))


### PR DESCRIPTION
Fixed the issue that prevented compilation with version 2.33.5 and later. This was caused by a change in the type definition of Expires in S3, which ZIO AWS did not support for custom type overrides

https://github.com/aws/aws-sdk-java-v2/blob/2.33.5/CHANGELOG.md#features-3
https://github.com/aws/aws-sdk-java-v2/compare/2.33.4...2.33.5#diff-0c19cbb17fa3190d5c04712680a323efb16a78723a1bffc5be874c32f26a371f