### PR TITLE
Revert "remove zio-mock dependency"

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -9,6 +9,7 @@ object Common extends AutoPlugin {
 
   object autoImport {
     val zioVersion = "2.1.21"
+    val zioMockVersion = "1.0.0-RC11"
     val zioCatsInteropVersion = "23.1.0.5"
     val zioReactiveStreamsInteropVersion = "2.0.2"
     val zioConfigVersion = "4.0.5"
@@ -71,6 +72,7 @@ object Common extends AutoPlugin {
       homepage := Some(url("https://github.com/zio/zio-aws")),
       awsLibraryVersion := awsVersion,
       zioLibraryVersion := zioVersion,
+      zioMockLibraryVersion := zioMockVersion,
       scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 12)) => scalacOptions212
         case Some((2, 13)) => scalacOptions213

--- a/zio-aws-codegen/src/main/scala/zio/aws/codegen/ZioAwsCodegenPlugin.scala
+++ b/zio-aws-codegen/src/main/scala/zio/aws/codegen/ZioAwsCodegenPlugin.scala
@@ -20,6 +20,9 @@ object ZioAwsCodegenPlugin extends AutoPlugin {
     val zioLibraryVersion = settingKey[String](
       "Specifies the version of the ZIO library to depend on"
     )
+    val zioMockLibraryVersion = settingKey[String](
+      "Specifies the version of the ZIO Mock library to depend on"
+    )
     val ciParallelJobs =
       settingKey[Int]("Number of parallel jobs in the generated circleCi file")
     val ciSeparateJobs = settingKey[Seq[String]](
@@ -236,6 +239,7 @@ object ZioAwsCodegenPlugin extends AutoPlugin {
             libraryDependencies += "software.amazon.awssdk" % id.name % awsLibraryVersion.value,
             libraryDependencies += "dev.zio" %% "zio" % zioLibraryVersion.value,
             libraryDependencies += "dev.zio" %% "zio-streams" % zioLibraryVersion.value,
+            libraryDependencies += "dev.zio" %% "zio-mock" % zioMockLibraryVersion.value,
             awsLibraryId := id.toString,
             Compile / sourceGenerators += generateSources.taskValue,
             Compile / packageSrc / mappings ++= {

--- a/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/ServiceInterfaceGenerator.scala
+++ b/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/ServiceInterfaceGenerator.scala
@@ -284,7 +284,16 @@ trait ServiceInterfaceGenerator {
           q"""def $methodName(request: ${requestType.typ}, input: ${Types
               .zioStreamAwsError(ScalaType.any, inEventT)
               .typ}): ${Types.zioStreamAwsError(serviceType, outEventRoT).typ} =
-                ${Types.zioStream_.term}.serviceWithStream(_.$methodName(request, input))"""
+                ${Types.zioStream_.term}.serviceWithStream(_.$methodName(request, input))""",
+        mockObject = q"""object $objectName extends Stream[${ScalaType
+            .pair(requestType, Types.zioStreamAwsError(ScalaType.any, inEventT))
+            .typ}, ${Types.awsError.typ}, ${outEventRoT.typ}]""",
+        mockCompose =
+          q"""def $methodName(request: ${requestType.typ}, input: ${Types
+              .zioStreamAwsError(ScalaType.any, inEventT)
+              .typ}): ${Types
+              .zioStreamAwsError(ScalaType.any, outEventRoT)
+              .typ} = ${unsafeRun(q"""proxy($objectName, request, input)""")}"""
       )
     )
   }
@@ -344,7 +353,12 @@ trait ServiceInterfaceGenerator {
         accessor = q"""def $methodName(request: ${requestType.typ}): ${Types
             .zioStreamAwsError(serviceType, eventRoT)
             .typ} =
-                ${Types.zioStream_.term}.serviceWithStream(_.$methodName(request))"""
+                ${Types.zioStream_.term}.serviceWithStream(_.$methodName(request))""",
+        mockObject =
+          q"""object $objectName extends Stream[${requestType.typ}, ${Types.awsError.typ}, ${eventRoT.typ}]""",
+        mockCompose = q"""def $methodName(request: ${requestType.typ}): ${Types
+            .zioStreamAwsError(ScalaType.any, eventRoT)
+            .typ} = ${unsafeRun(q"""proxy($objectName, request)""")}"""
       )
     )
   }
@@ -382,7 +396,16 @@ trait ServiceInterfaceGenerator {
           q"""def $methodName(request: ${requestType.typ}, input: ${Types
               .zioStreamAwsError(ScalaType.any, eventT)
               .typ}): ${Types.zioAwsError(serviceType, responseTypeRo).typ} =
-                ${Types.zio_.term}.serviceWithZIO(_.$methodName(request, input))"""
+                ${Types.zio_.term}.serviceWithZIO(_.$methodName(request, input))""",
+        mockObject = q"""object $objectName extends Effect[${ScalaType
+            .pair(requestType, Types.zioStreamAwsError(ScalaType.any, eventT))
+            .typ}, ${Types.awsError.typ}, ${responseTypeRo.typ}]""",
+        mockCompose =
+          q"""def $methodName(request: ${requestType.typ}, input: ${Types
+              .zioStreamAwsError(ScalaType.any, eventT)
+              .typ}): ${Types
+              .ioAwsError(responseTypeRo)
+              .typ} = proxy($objectName, request, input)"""
       )
     )
   }
@@ -448,7 +471,31 @@ trait ServiceInterfaceGenerator {
                     )
                   )
                   .typ} =
-                ${Types.zio_.term}.serviceWithZIO(_.$methodName(request, body))"""
+                ${Types.zio_.term}.serviceWithZIO(_.$methodName(request, body))""",
+            mockObject = q"""object $objectName extends Effect[${ScalaType
+                .pair(
+                  requestType,
+                  Types.zioStreamAwsError(ScalaType.any, ScalaType.byte)
+                )
+                .typ}, ${Types.awsError.typ}, ${Types
+                .streamingOutputResult(
+                  ScalaType.any,
+                  responseTypeRo,
+                  ScalaType.byte
+                )
+                .typ}]""",
+            mockCompose =
+              q"""def $methodName(request: ${requestType.typ}, body: ${Types
+                  .zioStreamAwsError(ScalaType.any, ScalaType.byte)
+                  .typ}): ${Types
+                  .ioAwsError(
+                    Types.streamingOutputResult(
+                      ScalaType.any,
+                      responseTypeRo,
+                      ScalaType.byte
+                    )
+                  )
+                  .typ} = proxy($objectName, request, body)"""
           )
         )
     }
@@ -503,7 +550,25 @@ trait ServiceInterfaceGenerator {
                 )
               )
               .typ} =
-                ${Types.zio_.term}.serviceWithZIO(_.$methodName(request))"""
+                ${Types.zio_.term}.serviceWithZIO(_.$methodName(request))""",
+          mockObject =
+            q"""object $objectName extends Effect[${requestType.typ}, ${Types.awsError.typ}, ${Types
+                .streamingOutputResult(
+                  ScalaType.any,
+                  responseTypeRo,
+                  ScalaType.byte
+                )
+                .typ}]""",
+          mockCompose =
+            q"""def $methodName(request: ${requestType.typ}): ${Types
+                .ioAwsError(
+                  Types.streamingOutputResult(
+                    ScalaType.any,
+                    responseTypeRo,
+                    ScalaType.byte
+                  )
+                )
+                .typ} = proxy($objectName, request)"""
         )
       )
     )
@@ -544,7 +609,19 @@ trait ServiceInterfaceGenerator {
                   .typ}): ${Types
                   .zioAwsError(serviceType, responseTypeRo)
                   .typ} =
-              ${Types.zio_.term}.serviceWithZIO(_.$methodName(request, body))"""
+              ${Types.zio_.term}.serviceWithZIO(_.$methodName(request, body))""",
+            mockObject = q"""object $objectName extends Effect[${ScalaType
+                .pair(
+                  requestType,
+                  Types.zioStreamAwsError(ScalaType.any, ScalaType.byte)
+                )
+                .typ}, ${Types.awsError.typ}, ${responseTypeRo.typ}]""",
+            mockCompose =
+              q"""def $methodName(request: ${requestType.typ}, body: ${Types
+                  .zioStreamAwsError(ScalaType.any, ScalaType.byte)
+                  .typ}): ${Types
+                  .ioAwsError(responseTypeRo)
+                  .typ} = proxy($objectName, request, body)"""
           )
         )
     }
@@ -587,7 +664,19 @@ trait ServiceInterfaceGenerator {
                   .typ}): ${Types
                   .zioAwsError(serviceType, ScalaType.unit)
                   .typ} =
-                ${Types.zio_.term}.serviceWithZIO(_.$methodName(request, body))"""
+                ${Types.zio_.term}.serviceWithZIO(_.$methodName(request, body))""",
+            mockObject = q"""object $objectName extends Effect[${ScalaType
+                .pair(
+                  requestType,
+                  Types.zioStreamAwsError(ScalaType.any, ScalaType.byte)
+                )
+                .typ}, ${Types.awsError.typ}, ${ScalaType.unit.typ}]""",
+            mockCompose =
+              q"""def $methodName(request: ${requestType.typ}, body: ${Types
+                  .zioStreamAwsError(ScalaType.any, ScalaType.byte)
+                  .typ}): ${Types
+                  .ioAwsError(ScalaType.unit)
+                  .typ} = proxy($objectName, request, body)"""
           )
         )
     }
@@ -627,7 +716,13 @@ trait ServiceInterfaceGenerator {
           q"""def $simpleMethodName(request: ${requestType.typ}): ${Types
               .zioAwsError(serviceType, responseTypeRo)
               .typ} =
-                ${Types.zio_.term}.serviceWithZIO(_.$simpleMethodName(request))"""
+                ${Types.zio_.term}.serviceWithZIO(_.$simpleMethodName(request))""",
+        mockObject =
+          q"""object $simpleObjectName extends Effect[${requestType.typ}, ${Types.awsError.typ}, ${responseTypeRo.typ}]""",
+        mockCompose =
+          q"""def $simpleMethodName(request: ${requestType.typ}):  ${Types
+              .ioAwsError(responseTypeRo)
+              .typ} = proxy($simpleObjectName, request)"""
       )
 
     pagination match {
@@ -664,7 +759,13 @@ trait ServiceInterfaceGenerator {
             accessor = q"""def $methodName(request: ${requestType.typ}): ${Types
                 .zioStream(serviceType, Types.awsError, wrappedItemType)
                 .typ} =
-                    ${Types.zioStream_.term}.serviceWithStream(_.$methodName(request))"""
+                    ${Types.zioStream_.term}.serviceWithStream(_.$methodName(request))""",
+            mockObject =
+              q"""object $objectName extends Stream[${requestType.typ}, ${Types.awsError.typ}, ${wrappedItemType.typ}]""",
+            mockCompose =
+              q"""def $methodName(request: ${requestType.typ}): ${Types
+                  .zioStreamAwsError(ScalaType.any, wrappedItemType)
+                  .typ} = ${unsafeRun(q"""proxy($objectName, request)""")}"""
           )
         } yield ServiceMethods(streamedPaginator, simpleRequestResponse)
       case Some(
@@ -704,7 +805,15 @@ trait ServiceInterfaceGenerator {
                       .zioStream(serviceType, Types.awsError, itemTypeRo)
                       .typ} =
                     ${Types.zioStream_.term}.serviceWithStream(_.$methodName(request))
-               """
+               """,
+                mockObject =
+                  q"""object $objectName extends Stream[${requestType.typ}, ${Types.awsError.typ}, ${itemTypeRo.typ}]""",
+                mockCompose =
+                  q"""def $methodName(request: ${requestType.typ}): ${Types
+                      .zioStreamAwsError(ScalaType.any, itemTypeRo)
+                      .typ} = ${unsafeRun(
+                      q"""proxy($objectName, request)"""
+                    )}"""
               )
             } else {
               ServiceMethod(
@@ -756,7 +865,26 @@ trait ServiceInterfaceGenerator {
                       )
                       .typ} =
                     ${Types.zio_.term}.serviceWithZIO(_.$methodName(request))
-               """
+               """,
+                mockObject =
+                  q"""object $objectName extends Effect[${requestType.typ}, ${Types.awsError.typ}, ${Types
+                      .streamingOutputResult(
+                        ScalaType.any,
+                        responseTypeRo,
+                        itemTypeRo
+                      )
+                      .typ}]""",
+                mockCompose =
+                  q"""def $methodName(request: ${requestType.typ}): ${Types
+                      .zioAwsError(
+                        ScalaType.any,
+                        Types.streamingOutputResult(
+                          ScalaType.any,
+                          responseTypeRo,
+                          itemTypeRo
+                        )
+                      )
+                      .typ} = proxy($objectName, request)"""
               )
             }
         } yield ServiceMethods(streamedPaginator, simpleRequestResponse)
@@ -835,7 +963,26 @@ trait ServiceInterfaceGenerator {
                 )
                 .typ} =
                     ${Types.zio_.term}.serviceWithZIO(_.$methodName(request))
-               """
+               """,
+            mockObject =
+              q"""object $objectName extends Effect[${requestType.typ}, ${Types.awsError.typ}, ${Types
+                  .streamingOutputResult(
+                    ScalaType.any,
+                    resultTypeRo,
+                    itemTypeRo
+                  )
+                  .typ}]""",
+            mockCompose =
+              q"""def  $methodName(request: ${requestType.typ}): ${Types
+                  .zioAwsError(
+                    ScalaType.any,
+                    Types.streamingOutputResult(
+                      ScalaType.any,
+                      resultTypeRo,
+                      itemTypeRo
+                    )
+                  )
+                  .typ} = proxy($objectName, request)"""
           )
         } yield ServiceMethods(paginator, simpleRequestResponse)
 
@@ -899,7 +1046,20 @@ trait ServiceInterfaceGenerator {
                       )
                       .typ} =
                     ${Types.zioStream_.term}.serviceWithStream(_.$methodName(request))
-               """
+               """,
+                mockObject =
+                  q"""object $objectName extends Stream[${requestType.typ}, ${Types.awsError.typ}, ${ScalaType
+                      .pair(keyTypeRo, valueTypeRo)
+                      .typ}]""",
+                mockCompose =
+                  q"""def $methodName(request: ${requestType.typ}): ${Types
+                      .zioStreamAwsError(
+                        ScalaType.any,
+                        ScalaType.pair(keyTypeRo, valueTypeRo)
+                      )
+                      .typ} = ${unsafeRun(
+                      q"""proxy($objectName, request)"""
+                    )}"""
               )
             } else {
               ServiceMethod(
@@ -949,7 +1109,25 @@ trait ServiceInterfaceGenerator {
                       )
                       .typ} =
                     ${Types.zio_.term}.serviceWithZIO(_.$methodName(request))
-               """
+               """,
+                mockObject =
+                  q"""object $objectName extends Effect[${requestType.typ}, ${Types.awsError.typ}, ${Types
+                      .streamingOutputResult(
+                        ScalaType.any,
+                        responseTypeRo,
+                        ScalaType.pair(keyTypeRo, valueTypeRo)
+                      )
+                      .typ}]""",
+                mockCompose =
+                  q"""def $methodName(request: ${requestType.typ}): ${Types
+                      .ioAwsError(
+                        Types.streamingOutputResult(
+                          ScalaType.any,
+                          responseTypeRo,
+                          ScalaType.pair(keyTypeRo, valueTypeRo)
+                        )
+                      )
+                      .typ} = proxy($objectName, request)"""
               )
             }
         } yield ServiceMethods(streamedPaginator, simpleRequestResponse)
@@ -991,7 +1169,15 @@ trait ServiceInterfaceGenerator {
                       .zioStreamAwsError(serviceType, itemTypeRo)
                       .typ} =
                     ${Types.zioStream_.term}.serviceWithStream(_.$methodName(request))
-               """
+               """,
+                mockObject =
+                  q"""object $objectName extends Stream[${requestType.typ}, ${Types.awsError.typ}, ${itemTypeRo.typ}]""",
+                mockCompose =
+                  q"""def $methodName(request: ${requestType.typ}): ${Types
+                      .zioStreamAwsError(ScalaType.any, itemTypeRo)
+                      .typ} = ${unsafeRun(
+                      q"""proxy($objectName, request)"""
+                    )}"""
               )
             } else {
               ServiceMethod(
@@ -1041,7 +1227,25 @@ trait ServiceInterfaceGenerator {
                       )
                       .typ} =
                     ${Types.zio_.term}.serviceWithZIO(_.$methodName(request))
-               """
+               """,
+                mockObject =
+                  q"""object $objectName extends Effect[${requestType.typ}, ${Types.awsError.typ}, ${Types
+                      .streamingOutputResult(
+                        ScalaType.any,
+                        responseTypeRo,
+                        itemTypeRo
+                      )
+                      .typ}]""",
+                mockCompose =
+                  q"""def $methodName(request: ${requestType.typ}): ${Types
+                      .ioAwsError(
+                        Types.streamingOutputResult(
+                          ScalaType.any,
+                          responseTypeRo,
+                          itemTypeRo
+                        )
+                      )
+                      .typ} = proxy($objectName, request)"""
               )
             }
         } yield ServiceMethods(streamedPaginator, simpleRequestResponse)
@@ -1077,7 +1281,13 @@ trait ServiceInterfaceGenerator {
           accessor = q"""def $methodName(request: ${requestType.typ}): ${Types
               .zioAwsError(serviceType, ScalaType.unit)
               .typ} =
-                ${Types.zio_.term}.serviceWithZIO(_.$methodName(request))"""
+                ${Types.zio_.term}.serviceWithZIO(_.$methodName(request))""",
+          mockObject =
+            q"""object $objectName extends Effect[${requestType.typ}, ${Types.awsError.typ}, ${ScalaType.unit.typ}]""",
+          mockCompose =
+            q"""def $methodName(request: ${requestType.typ}): ${Types
+                .ioAwsError(ScalaType.unit)
+                .typ} = proxy($objectName, request)"""
         )
       )
     )
@@ -1104,7 +1314,12 @@ trait ServiceInterfaceGenerator {
           accessor = q"""def $methodName(): ${Types
               .zioAwsError(serviceType, responseTypeRo)
               .typ} =
-                  ${Types.zio_.term}.serviceWithZIO(_.$methodName())"""
+                  ${Types.zio_.term}.serviceWithZIO(_.$methodName())""",
+          mockObject =
+            q"""object $objectName extends Effect[${ScalaType.unit.typ}, ${Types.awsError.typ}, ${responseTypeRo.typ}]""",
+          mockCompose = q"""def $methodName(): ${Types
+              .ioAwsError(responseTypeRo)
+              .typ} = proxy($objectName)"""
         )
       )
     )
@@ -1129,7 +1344,12 @@ trait ServiceInterfaceGenerator {
           accessor = q"""def $methodName(): ${Types
               .zioAwsError(serviceType, ScalaType.unit)
               .typ} =
-                ${Types.zio_.term}.serviceWithZIO(_.$methodName())"""
+                ${Types.zio_.term}.serviceWithZIO(_.$methodName())""",
+          mockObject =
+            q"""object $objectName extends Effect[${ScalaType.unit.typ}, ${Types.awsError.typ}, ${ScalaType.unit.typ}]""",
+          mockCompose = q"""def $methodName(): ${Types
+              .ioAwsError(ScalaType.unit)
+              .typ} = proxy($objectName)"""
         )
       )
     )
@@ -1184,6 +1404,7 @@ trait ServiceInterfaceGenerator {
           getModelPkg.map(_.parent)
       }
       serviceName = Term.Name(namingStrategy.getServiceName)
+      serviceNameMock = Term.Name(namingStrategy.getServiceName + "Mock")
       serviceImplName = Term.Name(serviceName.value + "Impl")
       serviceImplT = Type.Name(serviceImplName.value)
       serviceNameT = Type.Name(serviceName.value)
@@ -1214,6 +1435,12 @@ trait ServiceInterfaceGenerator {
       serviceMethodImpls =
         serviceMethods.flatMap(_.methods.map(_.implementation))
       serviceAccessors = serviceMethods.flatMap(_.methods.map(_.accessor))
+      serviceMethodMockObjects = serviceMethods.flatMap(
+        _.methods.map(_.mockObject)
+      )
+      serviceMethodMockComposeMethods = serviceMethods.flatMap(
+        _.methods.map(_.mockCompose)
+      )
 
       supportsHttp2 = id.name == "kinesis" || id.name == "transcribestreaming"
       supportsHttp2Lit = Lit.Boolean(supportsHttp2)
@@ -1229,6 +1456,24 @@ trait ServiceInterfaceGenerator {
           "shield",
           "waf"
         ).contains(id.name)
+
+      mockCompose = q"""
+        val compose: zio.URLayer[zio.mock.Proxy, $serviceNameT] =
+          zio.ZLayer {
+            zio.ZIO.service[zio.mock.Proxy].flatMap { proxy =>
+              withRuntime[zio.mock.Proxy, $serviceNameT] { rts =>
+                zio.ZIO.succeed {
+                  new ${Init(serviceNameT, Name.Anonymous(), List.empty)} {
+                    val api: ${clientInterface.typ} = null
+                    def withAspect[R1](newAspect: zio.aws.core.aspects.AwsCallAspect[R1], r: zio.ZEnvironment[R1]): $serviceNameT = this
+
+                    ..$serviceMethodMockComposeMethods
+                  }
+                }
+              }
+            }
+        }
+        """
 
       module = q"""
           import scala.jdk.CollectionConverters._
@@ -1287,7 +1532,18 @@ trait ServiceInterfaceGenerator {
       path <- Generator.generateScalaPackage(pkg, serviceName.value) {
         ZIO.succeed(module)
       }
-    } yield Set(path)
+      pathMock <- Generator.generateScalaPackage(pkg, serviceNameMock.value) {
+        ZIO.succeed {
+          q"""{
+            object $serviceNameMock extends zio.mock.Mock[$serviceNameT] {
+              ..$serviceMethodMockObjects
+
+              $mockCompose
+            }
+          }"""
+        }
+      }
+    } yield Set(path, pathMock)
 
   protected def generateServiceModule()
       : ZIO[Generator with AwsGeneratorContext, GeneratorFailure[

--- a/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/ServiceMethods.scala
+++ b/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/ServiceMethods.scala
@@ -5,7 +5,9 @@ import scala.meta._
 case class ServiceMethod(
     interface: Decl,
     implementation: Defn,
-    accessor: Defn
+    accessor: Defn,
+    mockObject: Defn,
+    mockCompose: Defn
 )
 
 case class ServiceMethods(methods: List[ServiceMethod])


### PR DESCRIPTION
Reverts zio/zio-aws#1620

we leverage zio-mocks quite heavily in ZIO DynamoDB. Prebuilt mocks offer a high level of convenience for us and it would be a lot of work to switch to something else, plus I need a later fix by Jules exposing hasL etc methods in zio-aws-dynamodb module as matter of some urgency. My vote would be for  reverting this PR for now as having zio-mock is doing no real harm, create an issue to track it and if we are to remove it at least think about replacing the functionality like for like (ie pre built mocks in some other lib) cc @guizmaii @vigoo 