### PR TITLE
fix: validate endpointOverride URI scheme (#626)

### DIFF
--- a/zio-aws-core/src/main/scala/zio/aws/core/config/descriptors/package.scala
+++ b/zio-aws-core/src/main/scala/zio/aws/core/config/descriptors/package.scala
@@ -16,14 +16,16 @@ package object descriptors {
    *
    * @see https://github.com/zio/zio-aws/issues/626
    */
-  val httpUri: Config[URI] = Config.uri.mapAttempt { uri =>
-    val scheme = uri.getScheme
-    if (scheme == null || (!scheme.equalsIgnoreCase("http") && !scheme.equalsIgnoreCase("https"))) {
-      throw new IllegalArgumentException(
-        s"Invalid endpoint URI '$uri': scheme must be 'http' or 'https' (e.g., 'http://localhost:9000')"
-      )
+  val httpUri: Config[URI] = Config.uri.mapOrFail { uri =>
+    Option(uri.getScheme).map(_.toLowerCase) match {
+      case Some("http") | Some("https") => Right(uri)
+      case _ =>
+        Left(
+          Config.Error.InvalidData(message =
+            s"Invalid endpoint URI '$uri': scheme must be 'http' or 'https' (e.g., 'http://localhost:9000')"
+          )
+        )
     }
-    uri
   }
 
   val awsCredentials: Config[AwsCredentials] =


### PR DESCRIPTION
## Summary                                                         
Add `httpUri` config descriptor that validates the URI scheme is `http` or `https`. This prevents runtime `NullPointerException` when invalid URIs (e.g., `minio:9000` without scheme) are passed to AWS SDK.

### Problem
When configuring `endpointOverride` with an invalid URI like `minio:9000` (missing scheme), the config parsing succeeds but AWS SDK throws NPE at runtime.                                          

### Solution                                                                      
  - Add `httpUri` descriptor that validates scheme is `http` or `https`
  - Provide clear error message at config time

### Changes
- `descriptors/package.scala`: Add `httpUri` descriptor with scheme validation
  - `CommonAwsConfigSpec.scala`: Add tests for valid/invalid endpoints 

Fixes #626   