### PR TITLE
migrate from localstack to floci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,7 +517,7 @@ jobs:
         zio-aws-kinesisanalytics/compile zio-aws-kinesisanalyticsv2/compile zio-aws-kinesisvideo/compile
         zio-aws-kinesisvideoarchivedmedia/compile zio-aws-kinesisvideomedia/compile
         zio-aws-kinesisvideosignaling/compile zio-aws-kinesisvideowebrtcstorage/compile
-        zio-aws-kms/compile zio-aws-lakeformation/compile zio-aws-lambda/compile zio-aws-lambdacore/compile
+        zio-aws-kms/compile zio-aws-lakeformation/compile zio-aws-lambda/compile
         zio-aws-lambdamicrovms/compile zio-aws-launchwizard/compile zio-aws-lexmodelbuilding/compile
         zio-aws-lexmodelsv2/compile zio-aws-lexruntime/compile zio-aws-lexruntimev2/compile
         zio-aws-licensemanager/compile zio-aws-licensemanagerlinuxsubscriptions/compile
@@ -552,7 +552,7 @@ jobs:
         zio-aws-kinesisvideo/publishSigned zio-aws-kinesisvideoarchivedmedia/publishSigned
         zio-aws-kinesisvideomedia/publishSigned zio-aws-kinesisvideosignaling/publishSigned
         zio-aws-kinesisvideowebrtcstorage/publishSigned zio-aws-kms/publishSigned
-        zio-aws-lakeformation/publishSigned zio-aws-lambda/publishSigned zio-aws-lambdacore/publishSigned
+        zio-aws-lakeformation/publishSigned zio-aws-lambda/publishSigned
         zio-aws-lambdamicrovms/publishSigned zio-aws-launchwizard/publishSigned zio-aws-lexmodelbuilding/publishSigned
         zio-aws-lexmodelsv2/publishSigned zio-aws-lexruntime/publishSigned zio-aws-lexruntimev2/publishSigned
         zio-aws-licensemanager/publishSigned zio-aws-licensemanagerlinuxsubscriptions/publishSigned

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,6 @@ name: CI
   push:
     branches:
     - master
-env:
-  LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
 jobs:
   tag:
     name: Tag build
@@ -126,19 +124,12 @@ jobs:
     needs:
     - build-core
     services:
-      localstack:
-        image: localstack/localstack:latest
+      floci:
+        image: floci/floci:latest
         env:
-          EAGER_SERVICE_LOADING: '1'
-          DEFAULT_REGION: us-east-1
-          DEBUG: '1'
-          SERVICES: s3,dynamodb
           AWS_ACCESS_KEY_ID: dummy-key
           AWS_SECRET_ACCESS_KEY: dummy-key
-          LOCALSTACK_HOST: localstack
           AWS_DEFAULT_REGION: us-east-1
-          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
-          USE_SSL: 'false'
         ports:
         - 4566:4566
     if: ${{ github.actor != 'github-actions[bot]' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,9 +127,9 @@ jobs:
       floci:
         image: floci/floci:latest
         env:
+          AWS_DEFAULT_REGION: us-east-1
           AWS_ACCESS_KEY_ID: dummy-key
           AWS_SECRET_ACCESS_KEY: dummy-key
-          AWS_DEFAULT_REGION: us-east-1
         ports:
         - 4566:4566
     if: ${{ github.actor != 'github-actions[bot]' }}
@@ -260,7 +260,7 @@ jobs:
         zio-aws-cloudtraildata/compile zio-aws-cloudwatch/compile zio-aws-cloudwatchevents/compile
         zio-aws-cloudwatchlogs/compile zio-aws-codeartifact/compile zio-aws-codebuild/compile
         zio-aws-codecatalyst/compile zio-aws-codecommit/compile zio-aws-codeconnections/compile
-        zio-aws-codedeploy/compile zio-aws-codeguruprofiler/compile
+        zio-aws-codedeploy/compile zio-aws-codeguruprofiler/compile zio-aws-codegurureviewer/compile
     - name: Build and publish libraries
       if: ${{ github.ref == 'refs/heads/master' }}
       run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-accessanalyzer/publishSigned
@@ -295,7 +295,7 @@ jobs:
         zio-aws-cloudwatch/publishSigned zio-aws-cloudwatchevents/publishSigned zio-aws-cloudwatchlogs/publishSigned
         zio-aws-codeartifact/publishSigned zio-aws-codebuild/publishSigned zio-aws-codecatalyst/publishSigned
         zio-aws-codecommit/publishSigned zio-aws-codeconnections/publishSigned zio-aws-codedeploy/publishSigned
-        zio-aws-codeguruprofiler/publishSigned
+        zio-aws-codeguruprofiler/publishSigned zio-aws-codegurureviewer/publishSigned
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -366,47 +366,46 @@ jobs:
         rm targets.tar
     - name: Build libraries
       if: ${{ github.ref != 'refs/heads/master' }}
-      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-codegurureviewer/compile
-        zio-aws-codegurusecurity/compile zio-aws-codepipeline/compile zio-aws-codestarconnections/compile
-        zio-aws-codestarnotifications/compile zio-aws-cognitoidentity/compile zio-aws-cognitoidentityprovider/compile
-        zio-aws-cognitosync/compile zio-aws-comprehend/compile zio-aws-comprehendmedical/compile
-        zio-aws-computeoptimizer/compile zio-aws-computeoptimizerautomation/compile
-        zio-aws-config/compile zio-aws-connect/compile zio-aws-connectcampaigns/compile
-        zio-aws-connectcampaignsv2/compile zio-aws-connectcases/compile zio-aws-connectcontactlens/compile
-        zio-aws-connecthealth/compile zio-aws-connectparticipant/compile zio-aws-controlcatalog/compile
-        zio-aws-controltower/compile zio-aws-costandusagereport/compile zio-aws-costexplorer/compile
-        zio-aws-costoptimizationhub/compile zio-aws-customerprofiles/compile zio-aws-databasemigration/compile
-        zio-aws-databrew/compile zio-aws-dataexchange/compile zio-aws-datapipeline/compile
-        zio-aws-datasync/compile zio-aws-datazone/compile zio-aws-dax/compile zio-aws-deadline/compile
-        zio-aws-detective/compile zio-aws-devicefarm/compile zio-aws-devopsagent/compile
-        zio-aws-devopsguru/compile zio-aws-directconnect/compile zio-aws-directory/compile
-        zio-aws-directoryservicedata/compile zio-aws-dlm/compile zio-aws-docdb/compile
-        zio-aws-docdbelastic/compile zio-aws-drs/compile zio-aws-dsql/compile zio-aws-dynamodb/compile
-        zio-aws-dynamodbstreams/compile zio-aws-ebs/compile zio-aws-ec2instanceconnect/compile
-        zio-aws-ecr/compile zio-aws-ecrpublic/compile zio-aws-ecs/compile zio-aws-efs/compile
-        zio-aws-eks/compile zio-aws-eksauth/compile zio-aws-elasticache/compile zio-aws-elasticbeanstalk/compile
-        zio-aws-elasticloadbalancing/compile zio-aws-elasticloadbalancingv2/compile
-        zio-aws-elasticsearch/compile zio-aws-elementalinference/compile zio-aws-emr/compile
-        zio-aws-emrcontainers/compile zio-aws-emrserverless/compile zio-aws-entityresolution/compile
-        zio-aws-eventbridge/compile zio-aws-evs/compile zio-aws-finspace/compile zio-aws-finspacedata/compile
-        zio-aws-firehose/compile zio-aws-fis/compile zio-aws-fms/compile zio-aws-forecast/compile
-        zio-aws-forecastquery/compile zio-aws-frauddetector/compile zio-aws-freetier/compile
-        zio-aws-fsx/compile zio-aws-gamelift/compile zio-aws-gameliftstreams/compile
-        zio-aws-geomaps/compile zio-aws-geoplaces/compile zio-aws-georoutes/compile
-        zio-aws-glacier/compile zio-aws-globalaccelerator/compile
+      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-codegurusecurity/compile
+        zio-aws-codepipeline/compile zio-aws-codestarconnections/compile zio-aws-codestarnotifications/compile
+        zio-aws-cognitoidentity/compile zio-aws-cognitoidentityprovider/compile zio-aws-cognitosync/compile
+        zio-aws-comprehend/compile zio-aws-comprehendmedical/compile zio-aws-computeoptimizer/compile
+        zio-aws-computeoptimizerautomation/compile zio-aws-config/compile zio-aws-connect/compile
+        zio-aws-connectcampaigns/compile zio-aws-connectcampaignsv2/compile zio-aws-connectcases/compile
+        zio-aws-connectcontactlens/compile zio-aws-connecthealth/compile zio-aws-connectparticipant/compile
+        zio-aws-controlcatalog/compile zio-aws-controltower/compile zio-aws-costandusagereport/compile
+        zio-aws-costexplorer/compile zio-aws-costoptimizationhub/compile zio-aws-customerprofiles/compile
+        zio-aws-databasemigration/compile zio-aws-databrew/compile zio-aws-dataexchange/compile
+        zio-aws-datapipeline/compile zio-aws-datasync/compile zio-aws-datazone/compile
+        zio-aws-dax/compile zio-aws-deadline/compile zio-aws-detective/compile zio-aws-devicefarm/compile
+        zio-aws-devopsagent/compile zio-aws-devopsguru/compile zio-aws-directconnect/compile
+        zio-aws-directory/compile zio-aws-directoryservicedata/compile zio-aws-dlm/compile
+        zio-aws-docdb/compile zio-aws-docdbelastic/compile zio-aws-drs/compile zio-aws-dsql/compile
+        zio-aws-dynamodb/compile zio-aws-dynamodbstreams/compile zio-aws-ebs/compile
+        zio-aws-ec2instanceconnect/compile zio-aws-ecr/compile zio-aws-ecrpublic/compile
+        zio-aws-ecs/compile zio-aws-efs/compile zio-aws-eks/compile zio-aws-eksauth/compile
+        zio-aws-elasticache/compile zio-aws-elasticbeanstalk/compile zio-aws-elasticloadbalancing/compile
+        zio-aws-elasticloadbalancingv2/compile zio-aws-elasticsearch/compile zio-aws-elementalinference/compile
+        zio-aws-emr/compile zio-aws-emrcontainers/compile zio-aws-emrserverless/compile
+        zio-aws-entityresolution/compile zio-aws-eventbridge/compile zio-aws-evs/compile
+        zio-aws-finspace/compile zio-aws-finspacedata/compile zio-aws-firehose/compile
+        zio-aws-fis/compile zio-aws-fms/compile zio-aws-forecast/compile zio-aws-forecastquery/compile
+        zio-aws-frauddetector/compile zio-aws-freetier/compile zio-aws-fsx/compile
+        zio-aws-gamelift/compile zio-aws-gameliftstreams/compile zio-aws-geomaps/compile
+        zio-aws-geoplaces/compile zio-aws-georoutes/compile zio-aws-glacier/compile
+        zio-aws-globalaccelerator/compile zio-aws-glue/compile zio-aws-grafana/compile
     - name: Build and publish libraries
       if: ${{ github.ref == 'refs/heads/master' }}
-      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-codegurureviewer/publishSigned
-        zio-aws-codegurusecurity/publishSigned zio-aws-codepipeline/publishSigned
-        zio-aws-codestarconnections/publishSigned zio-aws-codestarnotifications/publishSigned
-        zio-aws-cognitoidentity/publishSigned zio-aws-cognitoidentityprovider/publishSigned
-        zio-aws-cognitosync/publishSigned zio-aws-comprehend/publishSigned zio-aws-comprehendmedical/publishSigned
-        zio-aws-computeoptimizer/publishSigned zio-aws-computeoptimizerautomation/publishSigned
-        zio-aws-config/publishSigned zio-aws-connect/publishSigned zio-aws-connectcampaigns/publishSigned
-        zio-aws-connectcampaignsv2/publishSigned zio-aws-connectcases/publishSigned
-        zio-aws-connectcontactlens/publishSigned zio-aws-connecthealth/publishSigned
-        zio-aws-connectparticipant/publishSigned zio-aws-controlcatalog/publishSigned
-        zio-aws-controltower/publishSigned zio-aws-costandusagereport/publishSigned
+      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-codegurusecurity/publishSigned
+        zio-aws-codepipeline/publishSigned zio-aws-codestarconnections/publishSigned
+        zio-aws-codestarnotifications/publishSigned zio-aws-cognitoidentity/publishSigned
+        zio-aws-cognitoidentityprovider/publishSigned zio-aws-cognitosync/publishSigned
+        zio-aws-comprehend/publishSigned zio-aws-comprehendmedical/publishSigned zio-aws-computeoptimizer/publishSigned
+        zio-aws-computeoptimizerautomation/publishSigned zio-aws-config/publishSigned
+        zio-aws-connect/publishSigned zio-aws-connectcampaigns/publishSigned zio-aws-connectcampaignsv2/publishSigned
+        zio-aws-connectcases/publishSigned zio-aws-connectcontactlens/publishSigned
+        zio-aws-connecthealth/publishSigned zio-aws-connectparticipant/publishSigned
+        zio-aws-controlcatalog/publishSigned zio-aws-controltower/publishSigned zio-aws-costandusagereport/publishSigned
         zio-aws-costexplorer/publishSigned zio-aws-costoptimizationhub/publishSigned
         zio-aws-customerprofiles/publishSigned zio-aws-databasemigration/publishSigned
         zio-aws-databrew/publishSigned zio-aws-dataexchange/publishSigned zio-aws-datapipeline/publishSigned
@@ -429,7 +428,7 @@ jobs:
         zio-aws-frauddetector/publishSigned zio-aws-freetier/publishSigned zio-aws-fsx/publishSigned
         zio-aws-gamelift/publishSigned zio-aws-gameliftstreams/publishSigned zio-aws-geomaps/publishSigned
         zio-aws-geoplaces/publishSigned zio-aws-georoutes/publishSigned zio-aws-glacier/publishSigned
-        zio-aws-globalaccelerator/publishSigned
+        zio-aws-globalaccelerator/publishSigned zio-aws-glue/publishSigned zio-aws-grafana/publishSigned
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -500,10 +499,9 @@ jobs:
         rm targets.tar
     - name: Build libraries
       if: ${{ github.ref != 'refs/heads/master' }}
-      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-glue/compile
-        zio-aws-grafana/compile zio-aws-greengrass/compile zio-aws-greengrassv2/compile
-        zio-aws-groundstation/compile zio-aws-guardduty/compile zio-aws-health/compile
-        zio-aws-healthlake/compile zio-aws-iam/compile zio-aws-identitystore/compile
+      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-greengrass/compile
+        zio-aws-greengrassv2/compile zio-aws-groundstation/compile zio-aws-guardduty/compile
+        zio-aws-health/compile zio-aws-healthlake/compile zio-aws-iam/compile zio-aws-identitystore/compile
         zio-aws-imagebuilder/compile zio-aws-inspector/compile zio-aws-inspector2/compile
         zio-aws-inspectorscan/compile zio-aws-interconnect/compile zio-aws-internetmonitor/compile
         zio-aws-invoicing/compile zio-aws-iot/compile zio-aws-iotdataplane/compile
@@ -517,9 +515,10 @@ jobs:
         zio-aws-kinesisanalytics/compile zio-aws-kinesisanalyticsv2/compile zio-aws-kinesisvideo/compile
         zio-aws-kinesisvideoarchivedmedia/compile zio-aws-kinesisvideomedia/compile
         zio-aws-kinesisvideosignaling/compile zio-aws-kinesisvideowebrtcstorage/compile
-        zio-aws-kms/compile zio-aws-lakeformation/compile zio-aws-lambda/compile zio-aws-launchwizard/compile
-        zio-aws-lexmodelbuilding/compile zio-aws-lexmodelsv2/compile zio-aws-lexruntime/compile
-        zio-aws-lexruntimev2/compile zio-aws-licensemanager/compile zio-aws-licensemanagerlinuxsubscriptions/compile
+        zio-aws-kms/compile zio-aws-lakeformation/compile zio-aws-lambda/compile zio-aws-lambdacore/compile
+        zio-aws-lambdamicrovms/compile zio-aws-launchwizard/compile zio-aws-lexmodelbuilding/compile
+        zio-aws-lexmodelsv2/compile zio-aws-lexruntime/compile zio-aws-lexruntimev2/compile
+        zio-aws-licensemanager/compile zio-aws-licensemanagerlinuxsubscriptions/compile
         zio-aws-licensemanagerusersubscriptions/compile zio-aws-lightsail/compile
         zio-aws-location/compile zio-aws-lookoutequipment/compile zio-aws-m2/compile
         zio-aws-machinelearning/compile zio-aws-macie2/compile zio-aws-mailmanager/compile
@@ -530,29 +529,29 @@ jobs:
         zio-aws-marketplacereporting/compile zio-aws-mediaconnect/compile zio-aws-mediaconvert/compile
         zio-aws-medialive/compile zio-aws-mediapackage/compile zio-aws-mediapackagev2/compile
         zio-aws-mediapackagevod/compile zio-aws-mediastore/compile zio-aws-mediastoredata/compile
-        zio-aws-mediatailor/compile zio-aws-medicalimaging/compile
+        zio-aws-mediatailor/compile zio-aws-medicalimaging/compile zio-aws-memorydb/compile
     - name: Build and publish libraries
       if: ${{ github.ref == 'refs/heads/master' }}
-      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-glue/publishSigned
-        zio-aws-grafana/publishSigned zio-aws-greengrass/publishSigned zio-aws-greengrassv2/publishSigned
-        zio-aws-groundstation/publishSigned zio-aws-guardduty/publishSigned zio-aws-health/publishSigned
-        zio-aws-healthlake/publishSigned zio-aws-iam/publishSigned zio-aws-identitystore/publishSigned
-        zio-aws-imagebuilder/publishSigned zio-aws-inspector/publishSigned zio-aws-inspector2/publishSigned
-        zio-aws-inspectorscan/publishSigned zio-aws-interconnect/publishSigned zio-aws-internetmonitor/publishSigned
-        zio-aws-invoicing/publishSigned zio-aws-iot/publishSigned zio-aws-iotdataplane/publishSigned
-        zio-aws-iotdeviceadvisor/publishSigned zio-aws-iotevents/publishSigned zio-aws-ioteventsdata/publishSigned
-        zio-aws-iotfleetwise/publishSigned zio-aws-iotjobsdataplane/publishSigned
-        zio-aws-iotmanagedintegrations/publishSigned zio-aws-iotsecuretunneling/publishSigned
-        zio-aws-iotsitewise/publishSigned zio-aws-iotthingsgraph/publishSigned zio-aws-iottwinmaker/publishSigned
-        zio-aws-iotwireless/publishSigned zio-aws-ivs/publishSigned zio-aws-ivschat/publishSigned
-        zio-aws-ivsrealtime/publishSigned zio-aws-kafka/publishSigned zio-aws-kafkaconnect/publishSigned
-        zio-aws-kendra/publishSigned zio-aws-kendraranking/publishSigned zio-aws-keyspaces/publishSigned
-        zio-aws-keyspacesstreams/publishSigned zio-aws-kinesis/publishSigned zio-aws-kinesisanalytics/publishSigned
-        zio-aws-kinesisanalyticsv2/publishSigned zio-aws-kinesisvideo/publishSigned
-        zio-aws-kinesisvideoarchivedmedia/publishSigned zio-aws-kinesisvideomedia/publishSigned
-        zio-aws-kinesisvideosignaling/publishSigned zio-aws-kinesisvideowebrtcstorage/publishSigned
-        zio-aws-kms/publishSigned zio-aws-lakeformation/publishSigned zio-aws-lambda/publishSigned
-        zio-aws-launchwizard/publishSigned zio-aws-lexmodelbuilding/publishSigned
+      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-greengrass/publishSigned
+        zio-aws-greengrassv2/publishSigned zio-aws-groundstation/publishSigned zio-aws-guardduty/publishSigned
+        zio-aws-health/publishSigned zio-aws-healthlake/publishSigned zio-aws-iam/publishSigned
+        zio-aws-identitystore/publishSigned zio-aws-imagebuilder/publishSigned zio-aws-inspector/publishSigned
+        zio-aws-inspector2/publishSigned zio-aws-inspectorscan/publishSigned zio-aws-interconnect/publishSigned
+        zio-aws-internetmonitor/publishSigned zio-aws-invoicing/publishSigned zio-aws-iot/publishSigned
+        zio-aws-iotdataplane/publishSigned zio-aws-iotdeviceadvisor/publishSigned
+        zio-aws-iotevents/publishSigned zio-aws-ioteventsdata/publishSigned zio-aws-iotfleetwise/publishSigned
+        zio-aws-iotjobsdataplane/publishSigned zio-aws-iotmanagedintegrations/publishSigned
+        zio-aws-iotsecuretunneling/publishSigned zio-aws-iotsitewise/publishSigned
+        zio-aws-iotthingsgraph/publishSigned zio-aws-iottwinmaker/publishSigned zio-aws-iotwireless/publishSigned
+        zio-aws-ivs/publishSigned zio-aws-ivschat/publishSigned zio-aws-ivsrealtime/publishSigned
+        zio-aws-kafka/publishSigned zio-aws-kafkaconnect/publishSigned zio-aws-kendra/publishSigned
+        zio-aws-kendraranking/publishSigned zio-aws-keyspaces/publishSigned zio-aws-keyspacesstreams/publishSigned
+        zio-aws-kinesis/publishSigned zio-aws-kinesisanalytics/publishSigned zio-aws-kinesisanalyticsv2/publishSigned
+        zio-aws-kinesisvideo/publishSigned zio-aws-kinesisvideoarchivedmedia/publishSigned
+        zio-aws-kinesisvideomedia/publishSigned zio-aws-kinesisvideosignaling/publishSigned
+        zio-aws-kinesisvideowebrtcstorage/publishSigned zio-aws-kms/publishSigned
+        zio-aws-lakeformation/publishSigned zio-aws-lambda/publishSigned zio-aws-lambdacore/publishSigned
+        zio-aws-lambdamicrovms/publishSigned zio-aws-launchwizard/publishSigned zio-aws-lexmodelbuilding/publishSigned
         zio-aws-lexmodelsv2/publishSigned zio-aws-lexruntime/publishSigned zio-aws-lexruntimev2/publishSigned
         zio-aws-licensemanager/publishSigned zio-aws-licensemanagerlinuxsubscriptions/publishSigned
         zio-aws-licensemanagerusersubscriptions/publishSigned zio-aws-lightsail/publishSigned
@@ -566,7 +565,7 @@ jobs:
         zio-aws-mediaconnect/publishSigned zio-aws-mediaconvert/publishSigned zio-aws-medialive/publishSigned
         zio-aws-mediapackage/publishSigned zio-aws-mediapackagev2/publishSigned zio-aws-mediapackagevod/publishSigned
         zio-aws-mediastore/publishSigned zio-aws-mediastoredata/publishSigned zio-aws-mediatailor/publishSigned
-        zio-aws-medicalimaging/publishSigned
+        zio-aws-medicalimaging/publishSigned zio-aws-memorydb/publishSigned
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -637,39 +636,39 @@ jobs:
         rm targets.tar
     - name: Build libraries
       if: ${{ github.ref != 'refs/heads/master' }}
-      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-memorydb/compile
-        zio-aws-mgn/compile zio-aws-migrationhub/compile zio-aws-migrationhubconfig/compile
-        zio-aws-migrationhuborchestrator/compile zio-aws-migrationhubrefactorspaces/compile
-        zio-aws-migrationhubstrategy/compile zio-aws-mpa/compile zio-aws-mq/compile
-        zio-aws-mturk/compile zio-aws-mwaa/compile zio-aws-mwaaserverless/compile
-        zio-aws-neptune/compile zio-aws-neptunedata/compile zio-aws-neptunegraph/compile
-        zio-aws-networkfirewall/compile zio-aws-networkflowmonitor/compile zio-aws-networkmanager/compile
-        zio-aws-networkmonitor/compile zio-aws-notifications/compile zio-aws-notificationscontacts/compile
-        zio-aws-novaact/compile zio-aws-oam/compile zio-aws-observabilityadmin/compile
-        zio-aws-odb/compile zio-aws-omics/compile zio-aws-opensearch/compile zio-aws-opensearchserverless/compile
-        zio-aws-organizations/compile zio-aws-osis/compile zio-aws-outposts/compile
-        zio-aws-panorama/compile zio-aws-partnercentralaccount/compile zio-aws-partnercentralbenefits/compile
-        zio-aws-partnercentralchannel/compile zio-aws-partnercentralselling/compile
-        zio-aws-paymentcryptography/compile zio-aws-paymentcryptographydata/compile
-        zio-aws-pcaconnectorad/compile zio-aws-pcaconnectorscep/compile zio-aws-pcs/compile
-        zio-aws-personalize/compile zio-aws-personalizeevents/compile zio-aws-personalizeruntime/compile
-        zio-aws-pi/compile zio-aws-pinpoint/compile zio-aws-pinpointemail/compile
-        zio-aws-pinpointsmsvoice/compile zio-aws-pinpointsmsvoicev2/compile zio-aws-pipes/compile
-        zio-aws-polly/compile zio-aws-pricing/compile zio-aws-proton/compile zio-aws-qapps/compile
-        zio-aws-qbusiness/compile zio-aws-qconnect/compile zio-aws-quicksight/compile
+      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-mgn/compile
+        zio-aws-migrationhub/compile zio-aws-migrationhubconfig/compile zio-aws-migrationhuborchestrator/compile
+        zio-aws-migrationhubrefactorspaces/compile zio-aws-migrationhubstrategy/compile
+        zio-aws-mpa/compile zio-aws-mq/compile zio-aws-mturk/compile zio-aws-mwaa/compile
+        zio-aws-mwaaserverless/compile zio-aws-neptune/compile zio-aws-neptunedata/compile
+        zio-aws-neptunegraph/compile zio-aws-networkfirewall/compile zio-aws-networkflowmonitor/compile
+        zio-aws-networkmanager/compile zio-aws-networkmonitor/compile zio-aws-notifications/compile
+        zio-aws-notificationscontacts/compile zio-aws-novaact/compile zio-aws-oam/compile
+        zio-aws-observabilityadmin/compile zio-aws-odb/compile zio-aws-omics/compile
+        zio-aws-opensearch/compile zio-aws-opensearchserverless/compile zio-aws-organizations/compile
+        zio-aws-osis/compile zio-aws-outposts/compile zio-aws-panorama/compile zio-aws-partnercentralaccount/compile
+        zio-aws-partnercentralbenefits/compile zio-aws-partnercentralchannel/compile
+        zio-aws-partnercentralselling/compile zio-aws-paymentcryptography/compile
+        zio-aws-paymentcryptographydata/compile zio-aws-pcaconnectorad/compile zio-aws-pcaconnectorscep/compile
+        zio-aws-pcs/compile zio-aws-personalize/compile zio-aws-personalizeevents/compile
+        zio-aws-personalizeruntime/compile zio-aws-pi/compile zio-aws-pinpoint/compile
+        zio-aws-pinpointemail/compile zio-aws-pinpointsmsvoice/compile zio-aws-pinpointsmsvoicev2/compile
+        zio-aws-pipes/compile zio-aws-polly/compile zio-aws-pricing/compile zio-aws-proton/compile
+        zio-aws-qapps/compile zio-aws-qbusiness/compile zio-aws-qconnect/compile zio-aws-quicksight/compile
         zio-aws-ram/compile zio-aws-rbin/compile zio-aws-rds/compile zio-aws-rdsdata/compile
         zio-aws-redshift/compile zio-aws-redshiftdata/compile zio-aws-redshiftserverless/compile
         zio-aws-rekognition/compile zio-aws-repostspace/compile zio-aws-resiliencehub/compile
-        zio-aws-resourceexplorer2/compile zio-aws-resourcegroups/compile zio-aws-resourcegroupstaggingapi/compile
-        zio-aws-rolesanywhere/compile zio-aws-route53/compile zio-aws-route53domains/compile
-        zio-aws-route53globalresolver/compile zio-aws-route53profiles/compile zio-aws-route53recoverycluster/compile
-        zio-aws-route53recoverycontrolconfig/compile zio-aws-route53recoveryreadiness/compile
-        zio-aws-route53resolver/compile zio-aws-rtbfabric/compile zio-aws-rum/compile
-        zio-aws-s3/compile zio-aws-s3control/compile zio-aws-s3files/compile zio-aws-s3outposts/compile
+        zio-aws-resiliencehubv2/compile zio-aws-resourceexplorer2/compile zio-aws-resourcegroups/compile
+        zio-aws-resourcegroupstaggingapi/compile zio-aws-rolesanywhere/compile zio-aws-route53/compile
+        zio-aws-route53domains/compile zio-aws-route53globalresolver/compile zio-aws-route53profiles/compile
+        zio-aws-route53recoverycluster/compile zio-aws-route53recoverycontrolconfig/compile
+        zio-aws-route53recoveryreadiness/compile zio-aws-route53resolver/compile zio-aws-rtbfabric/compile
+        zio-aws-rum/compile zio-aws-s3/compile zio-aws-s3control/compile zio-aws-s3files/compile
+        zio-aws-s3outposts/compile zio-aws-s3tables/compile
     - name: Build and publish libraries
       if: ${{ github.ref == 'refs/heads/master' }}
-      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-memorydb/publishSigned
-        zio-aws-mgn/publishSigned zio-aws-migrationhub/publishSigned zio-aws-migrationhubconfig/publishSigned
+      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-mgn/publishSigned
+        zio-aws-migrationhub/publishSigned zio-aws-migrationhubconfig/publishSigned
         zio-aws-migrationhuborchestrator/publishSigned zio-aws-migrationhubrefactorspaces/publishSigned
         zio-aws-migrationhubstrategy/publishSigned zio-aws-mpa/publishSigned zio-aws-mq/publishSigned
         zio-aws-mturk/publishSigned zio-aws-mwaa/publishSigned zio-aws-mwaaserverless/publishSigned
@@ -694,14 +693,15 @@ jobs:
         zio-aws-ram/publishSigned zio-aws-rbin/publishSigned zio-aws-rds/publishSigned
         zio-aws-rdsdata/publishSigned zio-aws-redshift/publishSigned zio-aws-redshiftdata/publishSigned
         zio-aws-redshiftserverless/publishSigned zio-aws-rekognition/publishSigned
-        zio-aws-repostspace/publishSigned zio-aws-resiliencehub/publishSigned zio-aws-resourceexplorer2/publishSigned
-        zio-aws-resourcegroups/publishSigned zio-aws-resourcegroupstaggingapi/publishSigned
-        zio-aws-rolesanywhere/publishSigned zio-aws-route53/publishSigned zio-aws-route53domains/publishSigned
-        zio-aws-route53globalresolver/publishSigned zio-aws-route53profiles/publishSigned
-        zio-aws-route53recoverycluster/publishSigned zio-aws-route53recoverycontrolconfig/publishSigned
-        zio-aws-route53recoveryreadiness/publishSigned zio-aws-route53resolver/publishSigned
-        zio-aws-rtbfabric/publishSigned zio-aws-rum/publishSigned zio-aws-s3/publishSigned
-        zio-aws-s3control/publishSigned zio-aws-s3files/publishSigned zio-aws-s3outposts/publishSigned
+        zio-aws-repostspace/publishSigned zio-aws-resiliencehub/publishSigned zio-aws-resiliencehubv2/publishSigned
+        zio-aws-resourceexplorer2/publishSigned zio-aws-resourcegroups/publishSigned
+        zio-aws-resourcegroupstaggingapi/publishSigned zio-aws-rolesanywhere/publishSigned
+        zio-aws-route53/publishSigned zio-aws-route53domains/publishSigned zio-aws-route53globalresolver/publishSigned
+        zio-aws-route53profiles/publishSigned zio-aws-route53recoverycluster/publishSigned
+        zio-aws-route53recoverycontrolconfig/publishSigned zio-aws-route53recoveryreadiness/publishSigned
+        zio-aws-route53resolver/publishSigned zio-aws-rtbfabric/publishSigned zio-aws-rum/publishSigned
+        zio-aws-s3/publishSigned zio-aws-s3control/publishSigned zio-aws-s3files/publishSigned
+        zio-aws-s3outposts/publishSigned zio-aws-s3tables/publishSigned
       env:
         PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
         PGP_SECRET: ${{ secrets.PGP_SECRET }}
@@ -772,10 +772,10 @@ jobs:
         rm targets.tar
     - name: Build libraries
       if: ${{ github.ref != 'refs/heads/master' }}
-      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-s3tables/compile
-        zio-aws-s3vectors/compile zio-aws-sagemaker/compile zio-aws-sagemakera2iruntime/compile
-        zio-aws-sagemakeredge/compile zio-aws-sagemakerfeaturestoreruntime/compile
-        zio-aws-sagemakergeospatial/compile zio-aws-sagemakermetrics/compile zio-aws-sagemakerruntime/compile
+      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-s3vectors/compile
+        zio-aws-sagemaker/compile zio-aws-sagemakera2iruntime/compile zio-aws-sagemakeredge/compile
+        zio-aws-sagemakerfeaturestoreruntime/compile zio-aws-sagemakergeospatial/compile
+        zio-aws-sagemakerjobruntime/compile zio-aws-sagemakermetrics/compile zio-aws-sagemakerruntime/compile
         zio-aws-sagemakerruntimehttp2/compile zio-aws-savingsplans/compile zio-aws-scheduler/compile
         zio-aws-schemas/compile zio-aws-secretsmanager/compile zio-aws-securityagent/compile
         zio-aws-securityhub/compile zio-aws-securityir/compile zio-aws-securitylake/compile
@@ -801,14 +801,15 @@ jobs:
         zio-aws-workspacesthinclient/compile zio-aws-workspacesweb/compile zio-aws-xray/compile
     - name: Build and publish libraries
       if: ${{ github.ref == 'refs/heads/master' }}
-      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-s3tables/publishSigned
-        zio-aws-s3vectors/publishSigned zio-aws-sagemaker/publishSigned zio-aws-sagemakera2iruntime/publishSigned
+      run: sbt -J-XX:+UseG1GC -J-Xmx6g -J-Xms6g -J-Xss16m ++${{ matrix.scala }} zio-aws-s3vectors/publishSigned
+        zio-aws-sagemaker/publishSigned zio-aws-sagemakera2iruntime/publishSigned
         zio-aws-sagemakeredge/publishSigned zio-aws-sagemakerfeaturestoreruntime/publishSigned
-        zio-aws-sagemakergeospatial/publishSigned zio-aws-sagemakermetrics/publishSigned
-        zio-aws-sagemakerruntime/publishSigned zio-aws-sagemakerruntimehttp2/publishSigned
-        zio-aws-savingsplans/publishSigned zio-aws-scheduler/publishSigned zio-aws-schemas/publishSigned
-        zio-aws-secretsmanager/publishSigned zio-aws-securityagent/publishSigned zio-aws-securityhub/publishSigned
-        zio-aws-securityir/publishSigned zio-aws-securitylake/publishSigned zio-aws-serverlessapplicationrepository/publishSigned
+        zio-aws-sagemakergeospatial/publishSigned zio-aws-sagemakerjobruntime/publishSigned
+        zio-aws-sagemakermetrics/publishSigned zio-aws-sagemakerruntime/publishSigned
+        zio-aws-sagemakerruntimehttp2/publishSigned zio-aws-savingsplans/publishSigned
+        zio-aws-scheduler/publishSigned zio-aws-schemas/publishSigned zio-aws-secretsmanager/publishSigned
+        zio-aws-securityagent/publishSigned zio-aws-securityhub/publishSigned zio-aws-securityir/publishSigned
+        zio-aws-securitylake/publishSigned zio-aws-serverlessapplicationrepository/publishSigned
         zio-aws-servicecatalog/publishSigned zio-aws-servicecatalogappregistry/publishSigned
         zio-aws-servicediscovery/publishSigned zio-aws-servicequotas/publishSigned
         zio-aws-ses/publishSigned zio-aws-sesv2/publishSigned zio-aws-sfn/publishSigned

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,9 +127,11 @@ jobs:
       floci:
         image: floci/floci:latest
         env:
-          AWS_DEFAULT_REGION: us-east-1
+          QUARKUS_LOG_LEVEL: DEBUG
           AWS_ACCESS_KEY_ID: dummy-key
           AWS_SECRET_ACCESS_KEY: dummy-key
+          AWS_DEFAULT_REGION: us-east-1
+          FLOCI_HOSTNAME: localstack
         ports:
         - 4566:4566
     if: ${{ github.actor != 'github-actions[bot]' }}

--- a/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/GithubActionsGenerator.scala
+++ b/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/GithubActionsGenerator.scala
@@ -141,9 +141,11 @@ trait GithubActionsGenerator {
                 name = "floci",
                 image = ImageRef("floci/floci:latest"),
                 env = Map(
+                  "FLOCI_HOSTNAME" -> "localstack",
                   "AWS_DEFAULT_REGION" -> "us-east-1",
                   "AWS_ACCESS_KEY_ID" -> "dummy-key",
                   "AWS_SECRET_ACCESS_KEY" -> "dummy-key",
+                  "QUARKUS_LOG_LEVEL" -> "DEBUG"
                 ),
                 ports = Seq(
                   ServicePort(4566, 4566)

--- a/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/GithubActionsGenerator.scala
+++ b/zio-aws-codegen/src/main/scala/zio/aws/codegen/generator/GithubActionsGenerator.scala
@@ -53,11 +53,6 @@ trait GithubActionsGenerator {
             branches = Seq(Branch.Named("master"))
           )
         )
-        .withEnv(
-          Map(
-            "LOCALSTACK_AUTH_TOKEN" -> "${{ secrets.LOCALSTACK_AUTH_TOKEN }}"
-          )
-        )
         .addJob(
           Job(
             "tag",
@@ -143,19 +138,12 @@ trait GithubActionsGenerator {
           ).matrix(scalaVersions)
             .withServices(
               Service(
-                name = "localstack",
-                image = ImageRef("localstack/localstack:latest"),
+                name = "floci",
+                image = ImageRef("floci/floci:latest"),
                 env = Map(
-                  "LOCALSTACK_AUTH_TOKEN" -> "${{ secrets.LOCALSTACK_AUTH_TOKEN }}",
-                  "LOCALSTACK_HOST" -> "localstack",
-                  "SERVICES" -> "s3,dynamodb",
-                  "EAGER_SERVICE_LOADING" -> "1",
-                  "USE_SSL" -> "false",
-                  "DEFAULT_REGION" -> "us-east-1",
                   "AWS_DEFAULT_REGION" -> "us-east-1",
                   "AWS_ACCESS_KEY_ID" -> "dummy-key",
                   "AWS_SECRET_ACCESS_KEY" -> "dummy-key",
-                  "DEBUG" -> "1"
                 ),
                 ports = Seq(
                   ServicePort(4566, 4566)


### PR DESCRIPTION
Switched to floci because localstack's auth token cannot be used with forked Pull Requests